### PR TITLE
Chug not assigned

### DIFF
--- a/ChugBot.sql
+++ b/ChugBot.sql
@@ -32,6 +32,8 @@ pref_count int NOT NULL DEFAULT 6,
 regular_user_token varchar(255) NOT NULL DEFAULT 'kayitz',
 regular_user_token_hint varchar(512) DEFAULT 'Hebrew word for summer',
 pref_page_instructions varchar(2048) DEFAULT '&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose six Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;',
+`enable_camper_importer` int NOT NULL DEFAULT '1',
+`enable_selection_process` int NOT NULL DEFAULT '0',
 camp_name varchar(255) NOT NULL DEFAULT 'Camp Ramah New England',
 camp_web varchar(128) NOT NULL DEFAULT 'www.campramahne.org')
 COLLATE utf8_unicode_ci

--- a/ChugBotWithData.sql
+++ b/ChugBotWithData.sql
@@ -46,6 +46,8 @@ CREATE TABLE `admin_data` (
   `regular_user_token` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'kayitz',
   `regular_user_token_hint` varchar(512) COLLATE utf8_unicode_ci DEFAULT 'Hebrew word for summer',
   `pref_page_instructions` varchar(2048) COLLATE utf8_unicode_ci DEFAULT '&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose six Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;',
+  `enable_camper_importer` int NOT NULL DEFAULT '1',
+  `enable_selection_process` int NOT NULL DEFAULT '0',
   `camp_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'Camp Ramah New England',
   `camp_web` varchar(128) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'www.campramahne.org'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
@@ -57,7 +59,7 @@ CREATE TABLE `admin_data` (
 
 LOCK TABLES `admin_data` WRITE;
 /*!40000 ALTER TABLE `admin_data` DISABLE KEYS */;
-INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,'NULL','chug','chugim','block','blocks',1,6,'kayitz','Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose six Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Camp Ramah New England','www.campramahne.org');
+INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,'NULL','chug','chugim','block','blocks',1,6,'kayitz','Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose six Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;',1,0,'Camp Ramah New England','www.campramahne.org');
 /*!40000 ALTER TABLE `admin_data` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/chugbot/assignment.php
+++ b/chugbot/assignment.php
@@ -254,6 +254,8 @@ function do_assignment($edah_ids, $block_id, $group_id, &$err)
             return false;
         }
         while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+            // $row[4] contains each camper's first choice, so if it is null, they do not have choices recorded
+            // instead, pass over campers without preferences and DO NOT automatically assign them to chugim
             if(!is_null($row[4])) {
                 $c = new Camper($row[0], $row[1], $row[2], $row[3]);
                 for ($i = 4; $i < count($row); $i++) {

--- a/chugbot/assignment.php
+++ b/chugbot/assignment.php
@@ -254,16 +254,18 @@ function do_assignment($edah_ids, $block_id, $group_id, &$err)
             return false;
         }
         while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
-            $c = new Camper($row[0], $row[1], $row[2], $row[3]);
-            for ($i = 4; $i < count($row); $i++) {
-                if ($row[$i] >= 0) {
-                    array_push($c->prefs, $row[$i]);
+            if(!is_null($row[4])) {
+                $c = new Camper($row[0], $row[1], $row[2], $row[3]);
+                for ($i = 4; $i < count($row); $i++) {
+                    if ($row[$i] >= 0) {
+                        array_push($c->prefs, $row[$i]);
+                    }
                 }
+                $camper_id = intval($row[0]);
+                $campers[$camper_id] = $c;
+                array_push($camperIdsToAssign, $camper_id);
+                $camperId2EdahId[$camper_id] = $edah_id;
             }
-            $camper_id = intval($row[0]);
-            $campers[$camper_id] = $c;
-            array_push($camperIdsToAssign, $camper_id);
-            $camperId2EdahId[$camper_id] = $edah_id;
         }
     }
     if (count($campers) == 0) {

--- a/chugbot/levelHome.html
+++ b/chugbot/levelHome.html
@@ -72,6 +72,10 @@
     .li_fourth_choice {
       background: #ff3333;
     }
+
+    .li_no_pref {
+      background: #ef60ff;
+    }
   </style>
 
 </head>
@@ -88,6 +92,7 @@
       <span class="blocktermfill">BLOCK_TERM</span>. Assignments are highlighted according to the camper's preference:
       <span class="li_first_choice">first</span>, <span class="li_second_choice">second</span>,
       <span class="li_third_choice">third</span>, <span class="li_fourth_choice">fourth or worse</span>.
+      Campers with no preferences for a <span class="chugfill">CHUG</span> group are highlighted in <span class="li_no_pref">purple</span>.
     </p>
     <ul>
       <li>To change a camper's assignment, drag the camper's bubble from one
@@ -100,7 +105,9 @@
       <li>If a camper signed up late, or changed registration, they might not have
         an assignment yet. Such campers will appear in a box
         labeled <font color="red">Not Assigned Yet</font>. To assign these campers,
-        you can drag them to a <span class="chugfill">CHUG</span> and click Save, or click the Reassign button.</p>
+        you can drag them to a <span class="chugfill">CHUG</span> and click Save, or click the Reassign button.</li>
+      <li>NOTE: campers who have not submitted preferences are NOT automatically assigned; they are highlighted in <span class="li_no_pref">purple</span>
+        and appear in the <font color="red">Not Assigned Yet</font> box.</li></p>
       <li>To exit this page and return to the staff home page, click <b>Done</b>.
     </ul>
   </div>

--- a/chugbot/meta/leveling.js
+++ b/chugbot/meta/leveling.js
@@ -347,6 +347,9 @@ function getAndDisplayCurrentMatches() {
 									});
 								}
 							}
+							else {
+								prefClass = "li_no_pref";
+							}
 							var titleText = "title=\"<no preferences>\"";
 							if (prefListText) {
 								// If we have a pref list, write it as a tool tip.
@@ -478,6 +481,9 @@ function getAndDisplayCurrentMatches() {
 									}
 								});
 							}
+						}
+						else {
+							prefClass = "li_no_pref";
 						}
 						if (prefClass) {
 							$.each(prefClasses, function (index, prefClassToRemove) {

--- a/chugbot/meta/leveling.js
+++ b/chugbot/meta/leveling.js
@@ -346,6 +346,9 @@ function getAndDisplayCurrentMatches() {
 										}
 									});
 								}
+								else {
+									prefClass = "li_no_pref";
+								}
 							}
 							else {
 								prefClass = "li_no_pref";
@@ -480,6 +483,9 @@ function getAndDisplayCurrentMatches() {
 										return false; // break
 									}
 								});
+							}
+							else {
+								prefClass = "li_no_pref";
 							}
 						}
 						else {

--- a/chugbot/report.php
+++ b/chugbot/report.php
@@ -17,7 +17,7 @@ abstract class OutputTypes
 // A class to generate a printable PDF report.
 class PDF extends FPDF
 {
-    public function GenTable($title, $header, $data)
+    public function GenTable($title, $header, $data, $generateCheckboxes=true)
     {
         // Split line break in title into two lines.
         $titleParts = explode("<br>", $title);
@@ -73,11 +73,13 @@ class PDF extends FPDF
                 $this->SetXY($x + $w, $y);
             }
 
-            // add a set of blank checkboxes (used for things like attendance)
-            // to every row of every report
-            $NUM_OF_CHECKBOXES = 10;
-            foreach(range(1, $NUM_OF_CHECKBOXES) as $index) {
-                $this->Cell(10, 10, ' ', 1);
+            // optionaly add a set of blank checkboxes (used for things like attendance)
+            // to every row of every report (done by default)
+            if($generateCheckboxes) {
+                $NUM_OF_CHECKBOXES = 10;
+                foreach(range(1, $NUM_OF_CHECKBOXES) as $index) {
+                    $this->Cell(10, 10, ' ', 1);
+                }
             }
             $this->Ln($h);
             $fill = !$fill;
@@ -272,7 +274,7 @@ class ZebraReport
         return false;
     }
 
-    public function renderTable()
+    public function renderTable($generateCheckboxes=true)
     {
         if ($this->sql === null) {
             echo genFatalErrorReport(array("No table query was specified"));
@@ -330,7 +332,7 @@ class ZebraReport
                     // Add the table we just built to the PDF.
                     $pdf->AddPage();
                     $pdf->setColWidths($pdfColWidths);
-                    $pdf->GenTable($pdfCaptionText, $pdfHeader, $pdfData);
+                    $pdf->GenTable($pdfCaptionText, $pdfHeader, $pdfData, $generateCheckboxes);
                     // Re-initialize the PDF header and data arrays.  If we have
                     // CSV output, write the title, column headers, and data of
                     // the table we just built.
@@ -389,11 +391,20 @@ class ZebraReport
 
                 // Use the column keys as table headers.
                 $colKeys = array_keys($row);
+
+                // Count number of columns included
+                $numberOfColumns = 0;
+                foreach ($colKeys as $tableHeader) {
+                    if (!$this->shouldSkipColumn($tableHeader)) {
+                        $numberOfColumns++;
+                    }
+                }
+
                 foreach ($colKeys as $tableHeader) {
                     if ($this->shouldSkipColumn($tableHeader)) {
                         continue;
                     }
-                    $html .= "<th>$tableHeader</th>";
+                    $html .= "<th style=\"width: " . 100/$numberOfColumns . "%;\">$tableHeader</th>";
                     array_push($pdfHeader, $tableHeader);
                     // Initialize the width for the column corresponding to this
                     // header.
@@ -443,7 +454,7 @@ class ZebraReport
                         }
                     }
                 }
-                $html .= "<td>$tableData</td>";
+                $html .= "<td style=\"padding: 5px;\">$tableData</td>";
                 // Look up and replace the PDF/report column.
                 if (array_key_exists($tableDataKey, $this->idNameMapCols) &&
                     array_key_exists($d, $this->idNameMap)) {
@@ -466,14 +477,16 @@ class ZebraReport
                 $i++;
             }
 
-            // add a set of blank checkboxes (used for things like attendance)
-            // to every row of every report
-            $NUM_OF_CHECKBOXES = 10;
-            $html .= "<td style=\"font-size: 20px\">";
-            foreach(range(1, $NUM_OF_CHECKBOXES) as $index) {
-                $html .= "&#9744;&nbsp;";
+            // optionally add a set of blank checkboxes (used for things like attendance)
+            // to every row of every report (does by default)
+            if($generateCheckboxes) {
+                $NUM_OF_CHECKBOXES = 10;
+                $html .= "<td style=\"font-size: 20px\">";
+                foreach(range(1, $NUM_OF_CHECKBOXES) as $index) {
+                    $html .= "&#9744;&nbsp;";
+                }
+                $html .= "</td>";
             }
-            $html .= "</td>";
 
             $html .= "</tr>";
             array_push($pdfData, $pdfDataRow); // Save this row.
@@ -481,7 +494,7 @@ class ZebraReport
         }
         $pdf->AddPage();
         $pdf->setColWidths($pdfColWidths);
-        $pdf->GenTable($pdfCaptionText, $pdfHeader, $pdfData);
+        $pdf->GenTable($pdfCaptionText, $pdfHeader, $pdfData, $generateCheckboxes);
         $html .= "</table></div>";
 
         if ($this->outputType == OutputTypes::Pdf) {
@@ -495,11 +508,13 @@ class ZebraReport
             fputcsv($output, array($csvTitle));
             fputcsv($output, $pdfHeader);
             foreach ($pdfData as $pdfRow) {
-                // add a set of blank checkboxes (used for things like attendance)
-                // to every row of every report
-                $NUM_OF_CHECKBOXES = 10;
-                foreach(range(1, $NUM_OF_CHECKBOXES) as $index) {
-                    $pdfRow[str_repeat(' ', $index)] = ' ';
+                // optionally add a set of blank checkboxes (used for things like attendance)
+                // to every row of every report (does by default)
+                if($generateCheckboxes) {
+                    $NUM_OF_CHECKBOXES = 10;
+                    foreach(range(1, $NUM_OF_CHECKBOXES) as $index) {
+                        $pdfRow[str_repeat(' ', $index)] = ' ';
+                    }
                 }
 
                 fputcsv($output, $pdfRow);
@@ -559,7 +574,7 @@ function addActiveItemsToCaption(&$caption, $activeIdHash, $itemPluralName, $id2
 {
     if (!empty($activeIdHash)) {
         $ucName = ucfirst($itemPluralName);
-        $caption .= "<br><b>$ucName</b>: ";
+        $caption .= "<br><u>$ucName</u>: ";
         $ct = 0;
         foreach ($activeIdHash as $itemId => $active) {
             $itemName = $id2Name[$itemId];
@@ -584,6 +599,7 @@ abstract class ReportTypes
     const ChugimWithSpace = 7;
     const CamperHappiness = 8;
     const RegisteredMissingPrefs = 9;
+    const NotAssignedCampers = 10;
 }
 
 $dbErr = "";
@@ -603,6 +619,7 @@ $reportMethodId2Name = array(
     ReportTypes::ChugimWithSpace => ucfirst(chug_term_plural) . " With Free Space",
     ReportTypes::CamperHappiness => "Camper Happiness",
     ReportTypes::RegisteredMissingPrefs => "Campers Missing Preferences for Time " . ucfirst(block_term_plural),
+    ReportTypes::NotAssignedCampers => "Campers Not Assigned to " . ucfirst(chug_term_singular),
 );
 
 // Check for archived databases.
@@ -775,7 +792,7 @@ if ($outputType == OutputTypes::Html) {
 
 // Always show the report method drop-down and archive year menu (if any).
 $reportMethodDropDown = new FormItemDropDown("Report Type", true, "report_method", 0);
-$reportMethodDropDown->setGuideText("Step 1: Choose your report type.  Yoetzet/Rosh Edah report is by edah, Madrich by bunk, " . ucfirst(chug_term_singular) . " leader by " . chug_term_singular . ", and Director shows assignments for the whole camp.  Camper Prefs shows camper preferences and assignment, if any.  " . $reportMethodId2Name[ReportTypes::ChugimWithSpace] . " shows " . chug_term_plural . " with space remaining.  Campers missing preferences shows campers who are in the system, but who have not entered preferences for a particular time " . block_term_singular . ".");
+$reportMethodDropDown->setGuideText("<b>Step 1:</b> Choose your report type.  <br><u>Yoetzet/Rosh Edah</u> report is by edah.<br><u>Madrich</u> report is by bunk.<br><u>" . ucfirst(chug_term_singular) . " leader</u> report is by " . chug_term_singular . ".<br><u>Director</u> report shows assignments for the whole camp.<br><u>Camper Prefs</u> report shows camper preferences and assignment, if any.<br><u>" . $reportMethodId2Name[ReportTypes::ChugimWithSpace] . "</u> report shows " . chug_term_plural . " with space remaining.<br><u>Campers missing preferences</u> report shows campers who are in the system, but who have not entered preferences for a particular time " . block_term_singular . ".<br><u>Campers not Assigned to " . ucfirst(chug_term_singular) . "</u> report shows which campers do not yet have " . chug_term_singular . " assignments.");
 $reportMethodDropDown->setPlaceHolder("Choose Type");
 $reportMethodDropDown->setId2Name($reportMethodId2Name);
 $reportMethodDropDown->setColVal($reportMethod);
@@ -788,7 +805,7 @@ $archiveYearDropDown = null;
 if (!empty($availableArchiveYears)) {
     $defaultYear = yearOfCurrentSummer();
     $archiveYearDropDown = new FormItemDropDown("Year", false, "archive_year", 1);
-    $archiveYearDropDown->setGuideText("Optional: To view archived data from a previous summer, choose the year here. To see current data, leave this option set to $defaultYear.");
+    $archiveYearDropDown->setGuideText("<b>Optional:</b> To view archived data from a previous summer, choose the year here. To see current data, leave this option set to $defaultYear.");
     $archiveYearDropDown->setPlaceHolder("Current Year");
     $archiveYearDropDown->setId2Name($availableArchiveYears);
     $archiveYearDropDown->setColVal($archiveYear);
@@ -820,7 +837,7 @@ if ($reportMethod &&
     if ($reportMethod == ReportTypes::RegisteredMissingPrefs) {
         // For missing prefs, the user must select exactly one time block (to avoid confusion by the user).
         $blockChooser = new FormItemDropDown("Time " . ucfirst(block_term_plural) . " Missing Preferences", true, "block_id", $liNumCounter++);
-        $blockChooser->setGuideText("Step 2: Select one time " . block_term_singular . ". The report will show campers who are missing preferences for this " . block_term_singular . ".");
+        $blockChooser->setGuideText("<b>Step 2:</b> Select one time " . block_term_singular . ". The report will show campers who are missing preferences for this " . block_term_singular . ".");
         $blockChooser->setPlaceHolder("Choose a Time " . ucfirst(block_term_singular));
         $blockChooser->setInputClass("element select medium");
         $blockChooser->setId2Name($blockId2Name);
@@ -830,7 +847,7 @@ if ($reportMethod &&
         $blockChooser = new FormItemInstanceChooser("Time " . ucfirst(block_term_plural), false, "block_ids", $liNumCounter++);
         $blockChooser->setId2Name($blockId2Name);
         $blockChooser->setActiveIdHash($activeBlockIds);
-        $blockChooser->setGuideText("Step 2: Choose the time " . block_term_plural . " you wish to display.  If you do not choose any, all " . block_term_plural . " will be shown.");
+        $blockChooser->setGuideText("<b>Step 2:</b> Choose the time " . block_term_plural . " you wish to display.  If you do not choose any, all " . block_term_plural . " will be shown.");
     }
     if ($outputType == OutputTypes::Html) {
         echo $blockChooser->renderHtml();
@@ -843,14 +860,14 @@ if ($reportMethod == ReportTypes::ByEdah) {
     $edahChooser = new FormItemInstanceChooser("Edah Ids", false, "edah_ids", $liNumCounter++);
     $edahChooser->setId2Name($edahId2Name);
     $edahChooser->setActiveIdHash($activeEdahIds);
-    $edahChooser->setGuideText("Step 3: Choose one or more edot for your report, or leave empty to see all edot");
+    $edahChooser->setGuideText("<b>Step 3:</b> Choose one or more edot for your report, or leave empty to see all edot");
     if ($outputType == OutputTypes::Html) {
         echo $edahChooser->renderHtml();
     }
 } else if ($reportMethod == ReportTypes::ByBunk) {
     // Same as edah, but with a bunk filter.
     $bunkChooser = new FormItemDropDown("Bunk", false, "bunk_id", $liNumCounter++);
-    $bunkChooser->setGuideText("Step 3: Choose a bunk/tzrif, or leave empty to see all bunks");
+    $bunkChooser->setGuideText("<b>Step 3:</b> Choose a bunk/tzrif, or leave empty to see all bunks");
     $bunkChooser->setInputClass("element select medium");
     $bunkChooser->setInputSingular("bunk");
     $bunkChooser->setColVal($bunkId);
@@ -865,30 +882,32 @@ if ($reportMethod == ReportTypes::ByEdah) {
     $chugChooser = new FormItemInstanceChooser(ucfirst(chug_term_plural), true, "chug_ids", $liNumCounter++);
     $chugChooser->setId2Name($chugId2Name);
     $chugChooser->setActiveIdHash($activeChugIds);
-    $chugChooser->setGuideText("Step 3: Choose one or more " . chug_term_plural . " for this report.");
+    $chugChooser->setGuideText("<b>Step 3:</b> Choose one or more " . chug_term_plural . " for this report.");
 
     if ($outputType == OutputTypes::Html) {
         echo $chugChooser->renderHtml();
     }
 } else if ($reportMethod == ReportTypes::CamperChoices ||
     $reportMethod == ReportTypes::ChugimWithSpace ||
-    $reportMethod == ReportTypes::RegisteredMissingPrefs) {
+    $reportMethod == ReportTypes::RegisteredMissingPrefs ||
+    $reportMethod == ReportTypes::NotAssignedCampers) {
     // The camper choices report can be filtered by group and
-    // block.  The same applies to chugim with space.  Missing prefs is similar,
+    // block.  The same applies to chugim with space and campers not 
+    // assigned to a chug.  Missing prefs is similar,
     // except it filters by session and not by group.
     $edahChooser = new FormItemInstanceChooser("Show Campers in these Edot", false, "edah_ids", $liNumCounter++);
-    $edahChooser->setGuideText("Step 3: Choose one or more edot, or leave empty to see all edot.");
+    $edahChooser->setGuideText("<b>Step 3:</b> Choose one or more edot, or leave empty to see all edot.");
     $edahChooser->setActiveIdHash($activeEdahIds);
     $edahChooser->setId2Name($edahId2Name);
 
     if ($reportMethod == ReportTypes::RegisteredMissingPrefs) {
         $sessionChooser = new FormItemInstanceChooser("Show Campers Registered for these Sessions", false, "session_ids", $liNumCounter++);
-        $sessionChooser->setGuideText("Choose a session, or leave empty to see all sessions");
+        $sessionChooser->setGuideText("<b>Step 4:</b> Choose a session, or leave empty to see all sessions");
         $sessionChooser->setActiveIdHash($activeSessionIds);
         $sessionChooser->setId2Name($sessionId2Name);
     } else {
         $groupChooser = new FormItemInstanceChooser("Groups", false, "group_ids", $liNumCounter++);
-        $groupChooser->setGuideText("Choose on or more " . chug_term_singular . " groups, or leave empty to see all groups.");
+        $groupChooser->setGuideText("<b>Step 4:</b> Choose one or more " . chug_term_singular . " groups, or leave empty to see all groups.");
         $groupChooser->setActiveIdHash($activeGroupIds);
         $groupChooser->setId2Name($groupId2Name);
     }
@@ -912,12 +931,14 @@ if ($reportMethod == ReportTypes::ByEdah) {
     // here is 2, because we did not display a block filter.
     $step = ($reportMethod == ReportTypes::AllRegisteredCampers) ? 2 : 3;
     $edahChooser = new FormItemInstanceChooser("Show Campers in these Edot", false, "edah_ids", $liNumCounter++);
-    $edahChooser->setGuideText("Step $step: Choose one or more edot, or leave empty to see all edot.");
+    $edahChooser->setGuideText("<b>Step $step:</b> Choose one or more edot, or leave empty to see all edot.");
     $edahChooser->setActiveIdHash($activeEdahIds);
     $edahChooser->setId2Name($edahId2Name);
+    $step++;
+
 
     $sessionChooser = new FormItemInstanceChooser("Show Campers Registered for these Sessions", false, "session_ids", $liNumCounter++);
-    $sessionChooser->setGuideText("Choose a session, or leave empty to see all sessions");
+    $sessionChooser->setGuideText("<b>Step $step:</b> Choose a session, or leave empty to see all sessions");
     $sessionChooser->setActiveIdHash($activeSessionIds);
     $sessionChooser->setId2Name($sessionId2Name);
 
@@ -995,7 +1016,7 @@ if ($doReport) {
         //$allCampersReport->setCaption("LINK0 Campers in Session LINK1");
         //$allCampersReport->setIdCol2EditPage("edah_id", "editEdah.php", "edah");
         //$allCampersReport->setIdCol2EditPage("session_id", "editSession.php", "session");
-        $allCampersReport->renderTable();
+        $allCampersReport->renderTable($generateCheckboxes=false);
     } else if ($reportMethod == ReportTypes::ByEdah) {
         // Per-edah report.
         $sql = "SELECT CONCAT(c.last, ', ', c.first) AS name, IFNULL(b.name,\"-\") bunk, bl.name block, e.name edah, e.sort_order edah_sort_order, " .
@@ -1213,7 +1234,7 @@ if ($doReport) {
         $chugimWithSpaceReport->setCaption($caption);
         $chugimWithSpaceReport->setIdCol2EditPage("chug_id", "editChug.php", "chug_name");
         $chugimWithSpaceReport->addIgnoreColumn("max_campers");
-        $chugimWithSpaceReport->renderTable();
+        $chugimWithSpaceReport->renderTable($generateCheckboxes=false);
     } else if ($reportMethod == ReportTypes::CamperHappiness) {
         // First, get a list of all groups with at least one match for the selected
         // block/edot/session.  Use this to make a chug-group clause, which we'll
@@ -1310,7 +1331,7 @@ if ($doReport) {
         $camperHappinessReport->setIdCol2EditPage("block_id", "editBlock.php", "block");
         $camperHappinessReport->addIgnoreColumn("camper_id");
         $camperHappinessReport->addIgnoreColumn("block_id");
-        $camperHappinessReport->renderTable();
+        $camperHappinessReport->renderTable($generateCheckboxes=false);
     } else if ($reportMethod == ReportTypes::RegisteredMissingPrefs) {
         $sql = "SELECT DISTINCT a.name name, a.edah edah, a.session session FROM " .
             "(SELECT CONCAT(c.last, ', ', c.first) AS name, e.name edah, s.name session, p.preference_id pref_id " .
@@ -1341,7 +1362,55 @@ if ($doReport) {
         $campersMissingPrefsReport->setCaption($caption);
         //$campersMissingPrefsReport->addNewTableColumn("edah");
         //$campersMissingPrefsReport->addNewTableColumn("session");
-        $campersMissingPrefsReport->renderTable();
+        $campersMissingPrefsReport->renderTable($generateCheckboxes=false);
+    } else if ($reportMethod == ReportTypes::NotAssignedCampers) {
+        // Display a list of campers (by perek) who have not yet been assigned to a chug
+
+        // First, build an inner sql query creating a table with every camper and the desired chug groups/time blocks:
+        $inner = "SELECT CONCAT(c.last, ', ', c.first) AS name, c.camper_id AS c_id, c.edah_id, e.name AS edah, e.sort_order edah_sort_order, " .
+            "IFNULL(b.name,\"-\") bunk, bl.name AS block, bl.block_id as bl_id, c.camper_id, c.bunk_id, cg.name AS chug_group, cg.group_id " .
+            "FROM campers AS c " .
+            "JOIN edot AS e " .
+            "JOIN blocks AS bl " .
+            "JOIN chug_groups AS cg " .
+            "LEFT OUTER JOIN bunks b ON c.bunk_id = b.bunk_id";
+        
+        $haveWhere = false;
+        $haveWhere = addWhereClause($inner, $db, $activeGroupIds, "cg.group_id");
+        $haveWhere = addWhereClause($inner, $db, $activeBlockIds, "bl.block_id", $haveWhere);
+        $haveWhere = addWhereClause($inner, $db, $activeEdahIds, "c.edah_id", $haveWhere);
+
+        // Now, build the full query.
+        $fullSql = "SELECT * FROM (" . $inner . ") AS ca ";
+        $fullSql .= "LEFT OUTER JOIN (SELECT m.camper_id, m.chug_instance_id, i.block_id, i.chug_instance_id AS \"inst\", ch.chug_id, ch.group_id AS g_id " .
+            "FROM matches m, chug_instances i, chugim ch " .
+            "WHERE m.chug_instance_id=i.chug_instance_id AND ch.chug_id=i.chug_id) AS ma " .
+            "ON ma.camper_id=ca.camper_id AND ma.block_id=ca.bl_id AND ma.g_id=ca.group_id " .
+            "WHERE ma.chug_instance_id IS NULL " .
+            "ORDER BY edah_sort_order, edah, name, block, chug_group";
+        
+        $notAssignedReport = new ZebraReport($db, $fullSql, $outputType);
+        $caption = "Campers Missing " . ucfirst(chug_term_singular) . " Assignment(s)";
+        $notAssignedReport->setCaption($caption);
+
+        $notAssignedReport->setIdCol2EditPage("c_id", "editCamper.php", "name");
+        $notAssignedReport->setIdCol2EditPage("bunk_id", "editBunk.php", "bunk");
+        $notAssignedReport->setIdCol2EditPage("bl_id", "editBlock.php", "block");
+        $notAssignedReport->setIdCol2EditPage("group_id", "editGroup.php", "chug_group");
+        $notAssignedReport->setIdCol2EditPage("edah_id", "editEdah.php", "edah");
+
+        $notAssignedReport->addIgnoreColumn("block_id");
+        $notAssignedReport->addIgnoreColumn("bunk_id");
+        $notAssignedReport->addIgnoreColumn("edah_id");
+        $notAssignedReport->addIgnoreColumn("edah_sort_order");
+        $notAssignedReport->addIgnoreColumn("group_id");
+        $notAssignedReport->addIgnoreColumn("camper_id");
+        $notAssignedReport->addIgnoreColumn("chug_instance_id");
+        $notAssignedReport->addIgnoreColumn("inst");
+        $notAssignedReport->addIgnoreColumn("chug_id");
+        $notAssignedReport->addIgnoreColumn("g_id");
+
+        $notAssignedReport->renderTable($generateCheckboxes=false);
     }
 }
 


### PR DESCRIPTION
## Work Done
### Missing Chug Assignment(s) Report
- Generates report for campers who have not been assigned a chug (can filter by block, edah, and chug group)
- Some formatting on report menu (creating consistent styling of popup guides)
- Opt-out of generating checkboxes for certain reports (for both the HTML version and exported ones) by passing an additional parameter through (and adjusting the widths of each column row so everything is more visible) -- went in and removed checkboxes from reports in which I found it unnecessary

### Don't Assign Campers to Chug if no Preferences
- See title
- Designate campers without preferences on levelHome
    - Highlight campers with no preferences in purple
    - Improve instructions to include this information

## Testing Instructions
After running `./start.sh` to start the docker images, run `docker ps` and get the container id for image `mysql`

Using that container id, run (if id is 3342c74693b9) `docker exec -it 3342c74693b9 mysql -uroot -pdeveloper`

Copy and paste the following SQL commands (you may need to press enter after):
```
use camprama_chugbot_db;
insert into campers values(3,1,1,NULL,'Johnny','Appleseed','dlobron@gmail.com',0,0),(4,1,1,NULL,'David','Offit','dlobron@gmail.com',0,0); -- add additional campers
insert into blocks values(2,'Weeks 3+4',1); -- add additional chug block
insert into block_instances values(2,1); -- make block available for first session
insert into edot_for_block values(2,1); -- make block available for kochavim
insert into chug_groups values(2,'Bet'); -- add additional chug group
insert into edot_for_group values(2,1); -- make chug group available for kochavim
insert into chugim values('Dance',2,10000,-1,NULL,8),('Rikud',2,10000,-1,NULL,9),('Shira',2,10000,-1,NULL,10),('Zimkudiyah',2,10000,-1,NULL,11),('Shtik',2,10000,-1,NULL,12),('Clowning',2,10000,-1,NULL,13),('Juggling',2,10000,-1,NULL,14); -- add chugim for chug bet
insert into edot_for_chug values(8,1),(9,1),(10,1),(11,1),(12,1),(13,1),(14,1); -- make chugim available for kochavim
insert into chug_instances values(8,2,8),(9,2,9),(10,2,10),(11,2,11),(12,2,12),(13,2,13),(14,2,14),(8,1,15),(9,1,16),(10,1,17),(11,1,18),(12,1,19),(13,1,20),(14,1,21),(1,2,22),(2,2,23),(3,2,24),(4,2,25),(5,2,26),(6,2,27),(7,2,28); -- offer chugim for correct prakim for each time block
insert into preferences values(3,1,1,4,6,2,1,5,7,3),(2,2,1,9,8,10,12,11,14,4),(4,2,1,14,13,12,11,10,9,5); -- add some preferences for first block (weeks 1+2)
insert into preferences values(1,1,2,1,7,5,6,3,2,6),(2,1,2,7,6,5,4,3,2,7),(3,1,2,1,3,5,2,4,6,8),(4,2,2,14,12,10,13,11,9,9); -- add preferences for second block (weeks 3+4) (note - 3 campers now have preferences for chug aleph, but only 1 for chug bet)
```

Log into staff home (pwd: developer) and run the leveling report (you may need to click reassign, some matches already are made in the database and we’re building on those).
Expected output:
- Chug aleph, weeks 1+2: all assigned except David
- Chug bet, weeks 1+2: David and Johannes assigned, Igor and Johnny unassigned
- Chug aleph, weeks 3+4: all assigned except David
- Chug bet, weeks 3+4: all unassigned except David
    - Anyone unassigned should be in the “Not Assigned Yet” category, and their color should be purple, even if moved to a different category

Go to reports, and run the report for “Campers Not Assigned to Chug” with no additional options. The complete results from above will be reflected in a table.

Feel free to continue to experiment with assigning campers to chugim and adding/combining filters to the report. 

Additional note: when I was working locally, changes in the JS file did not apply by default because the file had been cached. You may need to clear your cache (and/or while on the local version of the website, go to Inspect Element-> Network->Disable caching) to see the changes.