### PR TITLE
Virtual Attendance System

### DIFF
--- a/ChugBotWithTestDBData.sql
+++ b/ChugBotWithTestDBData.sql
@@ -64,7 +64,7 @@ CREATE TABLE `admin_data` (
 
 LOCK TABLES `admin_data` WRITE;
 /*!40000 ALTER TABLE `admin_data` DISABLE KEYS */;
-INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,NULL,'Kayitz','the Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose three Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Ramah Day Camp DC','www.campramahne.org/day-camp-washington-dc/',3,0,'chug','chugim','block','blocks',1,1,1,'$2y$10$WYxSNvD2Obed2E8/8/9iFuJIOvw6cIkWzjPBZP4ZFUakv6pvURtoG','$2y$10$iLwZV5ZVjW5v7I9zw9ZdxeLyq0/I5RAX8iVSquSm2NdxSIYx6cAI6');
+INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,NULL,'Kayitz','the Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose three Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Ramah Day Camp DC','www.campramahne.org/day-camp-washington-dc/',3,0,'chug','chugim','block','blocks',1,1,1,'$2y$10$V9nDRWUrmMP8ZSpsGdv4UeTqYliiRSR2s922TOZ9apuA0fVaREp8S','$2y$10$uHwb1zE4wOT3eSstTI3PgO1BA8vhN8EoDToonlr0qyHmLRvGhMyNG');
 /*!40000 ALTER TABLE `admin_data` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -311,25 +311,6 @@ LOCK TABLES `category_tables` WRITE;
 INSERT INTO `category_tables` VALUES ('blocks',1,0),('bunks',2,1),('campers',3,1),('chugim',4,1),('edot',5,1),('chug_groups',6,0),('sessions',7,1);
 /*!40000 ALTER TABLE `category_tables` ENABLE KEYS */;
 UNLOCK TABLES;
-
---
--- Table structure for table `chug_attendance_taken`
---
-
-DROP TABLE IF EXISTS `chug_attendance_taken`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `chug_attendance_taken` (
-  `edah_id` int NOT NULL,
-  `date` date NOT NULL,
-  `chug_instance_id` int NOT NULL,
-  `chug_attendance_id` int NOT NULL AUTO_INCREMENT,
-  PRIMARY KEY (`chug_attendance_id`),
-  UNIQUE KEY `uk_chug_attendance_taken` (`edah_id`, `date`,`chug_instance_id`),
-  CONSTRAINT `chug_attendance_taken_ibfk_1` FOREIGN KEY (`edah_id`) REFERENCES `edot` (`edah_id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `chug_attendance_taken_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `chug_dedup_instances_v2`

--- a/ChugBotWithTestDBData.sql
+++ b/ChugBotWithTestDBData.sql
@@ -52,7 +52,9 @@ CREATE TABLE `admin_data` (
   `block_term_plural` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'blocks',
   `enable_camper_importer` tinyint(1) NOT NULL DEFAULT '0',
   `enable_selection_process` tinyint(1) NOT NULL DEFAULT '1',
-  `enable_camper_creation` tinyint(1) NOT NULL DEFAULT '1'
+  `enable_camper_creation` tinyint(1) NOT NULL DEFAULT '1',
+  `chug_leader_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `rosh_yoetzet_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -62,7 +64,7 @@ CREATE TABLE `admin_data` (
 
 LOCK TABLES `admin_data` WRITE;
 /*!40000 ALTER TABLE `admin_data` DISABLE KEYS */;
-INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,NULL,'Kayitz','the Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose three Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Ramah Day Camp DC','www.campramahne.org/day-camp-washington-dc/',3,0,'chug','chugim','block','blocks',1,1, 1);
+INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,NULL,'Kayitz','the Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose three Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Ramah Day Camp DC','www.campramahne.org/day-camp-washington-dc/',3,0,'chug','chugim','block','blocks',1,1,1,'$2y$10$WYxSNvD2Obed2E8/8/9iFuJIOvw6cIkWzjPBZP4ZFUakv6pvURtoG','$2y$10$iLwZV5ZVjW5v7I9zw9ZdxeLyq0/I5RAX8iVSquSm2NdxSIYx6cAI6');
 /*!40000 ALTER TABLE `admin_data` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -291,31 +293,23 @@ INSERT INTO `category_tables` VALUES ('blocks',1,0),('bunks',2,1),('campers',3,1
 UNLOCK TABLES;
 
 --
--- Table structure for table `chug_dedup_instances`
+-- Table structure for table `chug_attendance_taken`
 --
 
-DROP TABLE IF EXISTS `chug_dedup_instances`;
+DROP TABLE IF EXISTS `chug_attendance_taken`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `chug_dedup_instances` (
-  `left_chug_name` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `right_chug_name` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  UNIQUE KEY `uk_chug_dedup_instances` (`left_chug_name`,`right_chug_name`),
-  KEY `fk_right_chug_name` (`right_chug_name`),
-  CONSTRAINT `chug_dedup_instances_ibfk_1` FOREIGN KEY (`left_chug_name`) REFERENCES `chugim` (`name`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `chug_dedup_instances_ibfk_2` FOREIGN KEY (`right_chug_name`) REFERENCES `chugim` (`name`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE `chug_attendance_taken` (
+  `edah_id` int NOT NULL,
+  `date` date NOT NULL,
+  `chug_instance_id` int NOT NULL,
+  `chug_attendance_id` int NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`chug_attendance_id`),
+  UNIQUE KEY `uk_chug_attendance_taken` (`edah_id`, `date`,`chug_instance_id`),
+  CONSTRAINT `chug_attendance_taken_ibfk_1` FOREIGN KEY (`edah_id`) REFERENCES `edot` (`edah_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `chug_attendance_taken_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `chug_dedup_instances`
---
-
-LOCK TABLES `chug_dedup_instances` WRITE;
-/*!40000 ALTER TABLE `chug_dedup_instances` DISABLE KEYS */;
-INSERT INTO `chug_dedup_instances` VALUES ('Cooking','Cooking'),('Dance','Dance'),('Flag Football','Flag Football'),('Glass Painting','Glass Painting'),('Jewelry-Making','Jewelry-Making'),('Martial Arts','Martial Arts'),('Melty Beads','Melty Beads'),('Pickleball','Pickleball'),('Sand Art','Sand Art'),('Soccer','Soccer'),('Softball','Softball'),('Teva','Teva'),('Ultimate Frisbee','Ultimate Frisbee'),('Weaving, Sewing &amp; Needle-Point','Weaving, Sewing &amp; Needle-Point');
-/*!40000 ALTER TABLE `chug_dedup_instances` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `chug_dedup_instances_v2`
@@ -354,6 +348,7 @@ DROP TABLE IF EXISTS `chug_groups`;
 CREATE TABLE `chug_groups` (
   `group_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `active_block_id` int,
   PRIMARY KEY (`group_id`),
   UNIQUE KEY `uk_groups` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
@@ -365,7 +360,7 @@ CREATE TABLE `chug_groups` (
 
 LOCK TABLES `chug_groups` WRITE;
 /*!40000 ALTER TABLE `chug_groups` DISABLE KEYS */;
-INSERT INTO `chug_groups` VALUES (1,'Chug Aleph'),(2,'Chug Bet'),(4,'Chug Dalet'),(3,'Chug Gimel');
+INSERT INTO `chug_groups` VALUES (1,'Chug Aleph',1),(2,'Chug Bet',1),(4,'Chug Dalet',1),(3,'Chug Gimel',1);
 /*!40000 ALTER TABLE `chug_groups` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/ChugBotWithTestDBData.sql
+++ b/ChugBotWithTestDBData.sql
@@ -104,6 +104,25 @@ INSERT INTO `assignments` VALUES (1,1,1,32,7,1,0,'Softball (-2)','','2016-06-30 
 UNLOCK TABLES;
 
 --
+-- Table structure for table `attendance_present`
+--
+
+DROP TABLE IF EXISTS `attendance_present`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `attendance_present` (
+  `camper_id` int NOT NULL,
+  `date` date NOT NULL,
+  `chug_instance_id` int NOT NULL,
+  `attendance_id` int NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`attendance_id`),
+  UNIQUE KEY `uk_attendance_present` (`camper_id`,`date`,`chug_instance_id`),
+  CONSTRAINT `attendance_present_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `attendance_present_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `block_instances`
 --
 

--- a/ChugBotWithTestDBData.sql
+++ b/ChugBotWithTestDBData.sql
@@ -106,21 +106,41 @@ INSERT INTO `assignments` VALUES (1,1,1,32,7,1,0,'Softball (-2)','','2016-06-30 
 UNLOCK TABLES;
 
 --
--- Table structure for table `attendance_present`
+-- Table structure for table `attendance`
 --
 
-DROP TABLE IF EXISTS `attendance_present`;
+DROP TABLE IF EXISTS `attendance`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `attendance_present` (
+CREATE TABLE `attendance` (
   `camper_id` int NOT NULL,
   `date` date NOT NULL,
   `chug_instance_id` int NOT NULL,
+  `present` tinyint NOT NULL,
   `attendance_id` int NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`attendance_id`),
-  UNIQUE KEY `uk_attendance_present` (`camper_id`,`date`,`chug_instance_id`),
-  CONSTRAINT `attendance_present_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `attendance_present_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `uk_attendance` (`camper_id`,`date`,`chug_instance_id`),
+  CONSTRAINT `attendance_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `attendance_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `attendance_block_by_date`
+--
+
+DROP TABLE IF EXISTS `attendance_block_by_date`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `attendance_block_by_date` (
+  `date` date NOT NULL,
+  `group_id` int NOT NULL,
+  `block_id` int NOT NULL,
+  `attendance_block_by_date_id` int NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`attendance_block_by_date_id`),
+  UNIQUE KEY `uk_attendance_block_by_date` (`date`,`group_id`),
+  CONSTRAINT `attendance_block_by_date_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `chug_groups` (`group_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `attendance_block_by_date_ibfk_2` FOREIGN KEY (`block_id`) REFERENCES `blocks` (`block_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/Docker/ChugBotWithDataProdVers.sql
+++ b/Docker/ChugBotWithDataProdVers.sql
@@ -68,6 +68,25 @@ INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/X
 UNLOCK TABLES;
 
 --
+-- Table structure for table `attendance_present`
+--
+
+DROP TABLE IF EXISTS `attendance_present`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `attendance_present` (
+  `camper_id` int NOT NULL,
+  `date` date NOT NULL,
+  `chug_instance_id` int NOT NULL,
+  `attendance_id` int NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`attendance_id`),
+  UNIQUE KEY `uk_attendance_present` (`camper_id`,`date`,`chug_instance_id`),
+  CONSTRAINT `attendance_present_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `attendance_present_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `block_instances`
 --
 

--- a/Docker/ChugBotWithDataProdVers.sql
+++ b/Docker/ChugBotWithDataProdVers.sql
@@ -53,7 +53,9 @@ CREATE TABLE `admin_data` (
   `block_term_plural` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'blocks',
   `enable_camper_importer` tinyint(1) NOT NULL DEFAULT '0',
   `enable_selection_process` tinyint(1) NOT NULL DEFAULT '1',
-  `enable_camper_creation` tinyint(1) NOT NULL DEFAULT '1'
+  `enable_camper_creation` tinyint(1) NOT NULL DEFAULT '1',
+  `chug_leader_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `rosh_yoetzet_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -63,7 +65,7 @@ CREATE TABLE `admin_data` (
 
 LOCK TABLES `admin_data` WRITE;
 /*!40000 ALTER TABLE `admin_data` DISABLE KEYS */;
-INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,NULL,'Kayitz','the Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose three Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Ramah Day Camp DC','www.campramahne.org/day-camp-washington-dc/',3,0,'chug','chugim','block','blocks',1,1, 1);
+INSERT INTO `admin_data` VALUES ('dlobron@gmail.com','$2y$10$fqKUo0pkKj3kNTz8B/XsKuORY08cd7td5U3O2A2D.1Dl/Kfl2aGqu',NULL,NULL,'Kayitz','the Hebrew word for summer','&lt;h3&gt;How to Make Your Choices:&lt;/h3&gt;&lt;ol&gt;&lt;li&gt;For each time period, choose three Chugim, and drag them from the left column to the right column.  Hover over a Chug name in the left box to see a brief description.  If you have existing preferences, they will be pre-loaded in the right box: you can reorder or remove them as needed.&lt;/li&gt;&lt;li&gt;Use your mouse to drag the right column into order of preference, from top (first choice) to bottom (last choice).&lt;/li&gt;&lt;li&gt;When you have arranged preferences for all your time periods, click &lt;font color=&quot;green&quot;&gt;Submit&lt;/font&gt;.&lt;/li&gt;&lt;/ol&gt;','Ramah Day Camp DC','www.campramahne.org/day-camp-washington-dc/',3,0,'chug','chugim','block','blocks',1,1,1,'$2y$10$V9nDRWUrmMP8ZSpsGdv4UeTqYliiRSR2s922TOZ9apuA0fVaREp8S','$2y$10$uHwb1zE4wOT3eSstTI3PgO1BA8vhN8EoDToonlr0qyHmLRvGhMyNG');
 /*!40000 ALTER TABLE `admin_data` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -71,18 +73,42 @@ UNLOCK TABLES;
 -- Table structure for table `attendance_present`
 --
 
-DROP TABLE IF EXISTS `attendance_present`;
+--
+-- Table structure for table `attendance`
+--
+
+DROP TABLE IF EXISTS `attendance`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `attendance_present` (
+CREATE TABLE `attendance` (
   `camper_id` int NOT NULL,
   `date` date NOT NULL,
   `chug_instance_id` int NOT NULL,
+  `present` tinyint NOT NULL,
   `attendance_id` int NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`attendance_id`),
-  UNIQUE KEY `uk_attendance_present` (`camper_id`,`date`,`chug_instance_id`),
-  CONSTRAINT `attendance_present_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `attendance_present_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `uk_attendance` (`camper_id`,`date`,`chug_instance_id`),
+  CONSTRAINT `attendance_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `attendance_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `attendance_block_by_date`
+--
+
+DROP TABLE IF EXISTS `attendance_block_by_date`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `attendance_block_by_date` (
+  `date` date NOT NULL,
+  `group_id` int NOT NULL,
+  `block_id` int NOT NULL,
+  `attendance_block_by_date_id` int NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`attendance_block_by_date_id`),
+  UNIQUE KEY `uk_attendance_block_by_date` (`date`,`group_id`),
+  CONSTRAINT `attendance_block_by_date_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `chug_groups` (`group_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `attendance_block_by_date_ibfk_2` FOREIGN KEY (`block_id`) REFERENCES `blocks` (`block_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -288,6 +314,7 @@ DROP TABLE IF EXISTS `chug_groups`;
 CREATE TABLE `chug_groups` (
   `group_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
+  `active_block_id` int,
   PRIMARY KEY (`group_id`),
   UNIQUE KEY `uk_groups` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;

--- a/chugbot/addBlock.php
+++ b/chugbot/addBlock.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $block_term_singular = block_term_singular;

--- a/chugbot/addBunk.php
+++ b/chugbot/addBunk.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $addBunkPage = new AddPage("Add Bunk",
     "Please enter information for this bunk",

--- a/chugbot/addCamper.php
+++ b/chugbot/addCamper.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 camperBounceToLogin();
+checkLogout();
 
 $addCamperPage = new AddCamperPage("Add a Camper", "Step 1: Enter camper information",
     "campers", "camper_id");

--- a/chugbot/addChug.php
+++ b/chugbot/addChug.php
@@ -4,6 +4,7 @@ include_once 'addEdit.php';
 include_once 'formItem.php';
 include_once 'dbConn.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $addChugPage = new AddPage("Add " . ucfirst(chug_term_singular),

--- a/chugbot/addEdah.php
+++ b/chugbot/addEdah.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $addEdahPage = new AddPage("Add Edah",
     "Please enter your edah information",

--- a/chugbot/addEdit.php
+++ b/chugbot/addEdit.php
@@ -183,7 +183,8 @@ abstract class AddEditBase extends FormPage
         $actionTarget = htmlspecialchars($_SERVER["PHP_SELF"]);
         $html = "";
         if ($this->resultStr) {
-            $html .= "<div class=\"card card-body\">$this->resultStr</div>";
+            $html .= "<div class=\"row justify-content-center\"><div class=\"col-8 mt-4 p-0\"><div class=\"alert alert-success alert-dismissible fade show\" role=\"alert\">" . 
+            "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button>$this->resultStr</div></div></div>";
         }
         $secondParagraphHtml = "";
         if ($this->secondParagraph) {

--- a/chugbot/addGroup.php
+++ b/chugbot/addGroup.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $addGroupPage = new AddPage("Add Group",
     "Please enter your group information",

--- a/chugbot/addSession.php
+++ b/chugbot/addSession.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $addSessionPage = new AddPage("Add Session",
     "Please enter session information",

--- a/chugbot/advanced.php
+++ b/chugbot/advanced.php
@@ -4,6 +4,7 @@ include_once 'functions.php';
 include_once 'dbConn.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $edahId2Name = array();

--- a/chugbot/archive.php
+++ b/chugbot/archive.php
@@ -5,6 +5,7 @@ include_once 'functions.php';
 include_once 'constants.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 // Create an ID to name mapping for tables that we might clear.  We clear
 // these tables from the current DB unless the user instructs us not to.

--- a/chugbot/archive.php
+++ b/chugbot/archive.php
@@ -218,12 +218,12 @@ if (!$haveDb) {
 $binaryNotFoundError = "";
 $mysqldump = MYSQL_PATH . "/mysqldump";
 $mysql = MYSQL_PATH . "/mysql";
-/*if (!file_exists($mysqldump)) {
+if (!file_exists($mysqldump)) {
     $binaryNotFoundError = "DB backup utility not found at $mysqldump: check with administrator<br>";
 }
 if (!file_exists($mysql)) {
     $binaryNotFoundError .= "DB utility not found at $mysql: check with administrator<br>";
-}*/
+}
 
 // Check the GET data to find out what action to take.
 if ($_SERVER["REQUEST_METHOD"] == "GET" &&

--- a/chugbot/attendance/chugLeaderHome.php
+++ b/chugbot/attendance/chugLeaderHome.php
@@ -23,6 +23,15 @@
 
     echo headerText(ucfirst(chug_term_singular) . " Leader Home");
 
+    if(!attendanceActive()) {
+        $fullErrorMsg = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+        "Attendance Disabled</h5>Nothing is available to take attendance for; attendance has been disabled. " .
+        "Contact an administrator if you believe to be receiving this message in error.</div></div>";
+        echo $fullErrorMsg;
+        exit();
+    }
+
 ?>
     <!-- Uses choices-js, more info at https://github.com/Choices-js/Choices -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
@@ -54,7 +63,7 @@
         <li style="margin:auto;" class="ps-0">
             <label class="description" for="date"><span style="color:red;">*</span>Date</label>
             <div id="date_pick" class="pb-2">
-                <input type="date" id="date" name="date" class="form-control medium">
+                <input type="date" id="date" name="date" class="form-control medium" required>
             </div>
         </li>
         <li style="margin:auto;" class="ps-0">
@@ -145,3 +154,17 @@ function validateForm() {
 </script>
 
 </body>
+
+<?php
+function attendanceActive() {
+    $db = new dbConn();
+    $dbErr = "";
+    $db->addSelectColumn("count(active_block_id)");
+    $result = $db->simpleSelectFromTable("chug_groups", $dbErr);
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+        // just gets the count of active blocks
+        return $row[0] > 0;
+    }
+    return false;
+}
+?>

--- a/chugbot/attendance/chugLeaderHome.php
+++ b/chugbot/attendance/chugLeaderHome.php
@@ -1,0 +1,137 @@
+<?php
+    session_start();
+    include_once '../dbConn.php';
+    include_once '../functions.php';
+    bounceToLogin();
+    setup_camp_specific_terminology_constants();
+
+    $dbErr = "";
+    $sessionId2Name = array();
+    $blockId2Name = array();
+    $groupId2Name = array();
+    $edahId2Name = array();
+    $chugId2Name = array();
+    $bunkId2Name = array();
+
+    fillId2Name(null, $chugId2Name, $dbErr, "chug_id", "chugim", "group_id", "chug_groups");
+    fillId2Name(null, $sessionId2Name, $dbErr, "session_id", "sessions");
+    fillId2Name(null, $blockId2Name, $dbErr, "block_id", "blocks");
+    fillId2Name(null, $groupId2Name, $dbErr, "group_id", "chug_groups");
+    fillId2Name(null, $edahId2Name, $dbErr, "edah_id", "edot");
+    fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
+
+    echo headerText(ucfirst(chug_term_singular) . " Leader Home");
+
+?>
+    <!-- Uses choices-js, more info at https://github.com/Choices-js/Choices -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', (event) => {
+
+            const elements = document.querySelectorAll('.choices-js');
+            elements.forEach((element) =>  {
+                const choices = new Choices(element, {
+                    shouldSort: false,
+                    allowHTML: true,
+                    searchChoices: false
+                });
+            });
+        });
+    </script>
+
+<div class="container row justify-content-center" style="margin:auto;"><div id="errors" class="mt-2"></div></div>
+
+<div class="card card-body mt-2 p-3 mb-3 container">
+    <h1><?php echo ucfirst(chug_term_singular)?> Leader Home</h1>
+    <div class="page-header"><h2><?php echo ucfirst(chug_term_singular)?> Leader Home</h2>
+    <p>In the form below, select the date, edah, perek, and <?php echo chug_term_singular?> you are taking attendance for.
+    After clicking "Take Attendance" below the form, check the box for each camper who is <strong>present</strong>. Then press "submit" to complete the attendance.</p>
+    
+    <form id="attendance_chug_select_form" class="justify-content-center" method="GET" action="takeAttendance.php" onsubmit="return validateForm()"><ul>
+        <li style="margin:auto;" class="ps-0">
+            <label class="description" for="date"><span style="color:red;">*</span>Date</label>
+            <div id="date_pick" class="pb-2">
+                <input type="date" id="date" name="date" class="form-control medium">
+            </div>
+        </li>
+        <li style="margin:auto;" class="ps-0">
+            <label class="description" for="edah"><span style="color:red;">*</span>Edah/Edot</label>
+            <div id="edah_select" class="pb-2">
+                <select class="form-select bg-info choices-js" id="edah_list" name="edah" onchange="fillConstraintsPickList(); fillChugimConstraintsPickList();" multiple>
+                    <?php echo genPickList($edahId2Name, array(), "edah"); ?>
+                </select>
+            </div>
+        </li>
+        <li style="margin:auto;" class="ps-0"> 
+            <label class="description" for="group" id="group_desc"><span style="color:red;">*</span>Perek</label>
+            <div id="group_select" class="pb-2">
+                <?php echo genConstrainedPickListScript("group_select", "edah", "group_desc", "group", true); ?>
+            </div>
+        </li>
+        <li style="margin:auto;" class="ps-0">
+            <label class="description" for="chug" id="chug_desc"><span style="color:red;">*</span><?php echo ucfirst(chug_term_singular) ?></label>
+            <div id="chug_select" class="pb-2">
+                <?php echo genChugimPickListScript("chug_select", "edah", "group", "chug_desc", "chug", true); ?>
+            </div>
+        </li>
+        <li style="margin:auto;">
+            <div class="row justify-content-center">
+                <div class="col-6" style="text-align:center;"><button class="btn btn-primary" type="submit" id="submit_btn">Take Attendance</button></div>
+            </div>
+        </li>
+    </ul></form>
+
+</div>
+
+<script>
+// automatically set date to "today"
+document.getElementById('date').valueAsDate = new Date();
+
+
+function validateForm() {
+    var error = "<div class=\"alert alert-danger alert-dismissible fade show mb-0 ms-2 me-2\" role=\"alert\">";
+    error += "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button>";
+    error += "<h5><strong>Error:</strong> Not all required fields are complete</h5><ul class=\"mb-0\">";
+
+    let valid = true;
+
+    // ensure each required field is filled out - first check field exists, then that it has a value
+    fields = ["date", "edah", "group", "chug"];
+    fields.forEach((field) => {
+        let x = document.forms["attendance_chug_select_form"][field];
+        if(field === "group") { field = "perek"; } // small override to keep backend and UI consistent with each other
+        // check field exists
+        if(x === undefined) {
+            error += "<li><strong>"+field[0].toUpperCase() + field.slice(1)+"</strong> missing</li>";
+            valid = false;
+        }
+        else {
+            // check field has value
+            x = x.value;
+            if (x == "") {
+                error += "<li><strong>"+field[0].toUpperCase() + field.slice(1)+"</strong> missing</li>";
+                valid = false;
+            }
+        }
+    });
+
+    error += "</ul></div>";    
+
+    if(!valid) {
+        // if form is not ready to submit, show errors and cancel submission
+        var errorDiv = document.getElementById("errors");
+        errorDiv.innerHTML = error;
+        return false;
+    }
+    else {
+        // an extra field (a "search term") is being submitted because of the dropdown; this disables that
+        const cloned = document.getElementsByClassName("choices__input--cloned");
+        cloned[0].setAttribute('disabled', 'true');
+        cloned[1].setAttribute('disabled', 'true');
+        // then just automatically submits!
+    }
+}
+</script>
+
+</body>

--- a/chugbot/attendance/chugLeaderHome.php
+++ b/chugbot/attendance/chugLeaderHome.php
@@ -98,10 +98,11 @@ function validateForm() {
     let valid = true;
 
     // ensure each required field is filled out - first check field exists, then that it has a value
-    fields = ["date", "edah", "group", "chug"];
+    fields = ["date", "edah[]", "group", "chug"];
     fields.forEach((field) => {
         let x = document.forms["attendance_chug_select_form"][field];
         if(field === "group") { field = "perek"; } // small override to keep backend and UI consistent with each other
+        if(field === "edah[]") { field = "edah"; } // add'l change so user just sees "Edah," not "Edah[]"
         // check field exists
         if(x === undefined) {
             error += "<li><strong>"+field[0].toUpperCase() + field.slice(1)+"</strong> missing</li>";

--- a/chugbot/attendance/chugLeaderHome.php
+++ b/chugbot/attendance/chugLeaderHome.php
@@ -34,7 +34,8 @@
                 const choices = new Choices(element, {
                     shouldSort: false,
                     allowHTML: true,
-                    searchChoices: false
+                    searchChoices: false,
+                    removeItemButton: true,
                 });
             });
         });
@@ -56,9 +57,9 @@
             </div>
         </li>
         <li style="margin:auto;" class="ps-0">
-            <label class="description" for="edah"><span style="color:red;">*</span>Edah/Edot</label>
+            <label class="description" for="edah[]"><span style="color:red;">*</span>Edah/Edot</label>
             <div id="edah_select" class="pb-2">
-                <select class="form-select bg-info choices-js" id="edah_list" name="edah" onchange="fillConstraintsPickList(); fillChugimConstraintsPickList();" multiple>
+                <select class="form-select bg-info choices-js" id="edah_list" name="edah[]" onchange="fillConstraintsPickList(); fillChugimConstraintsPickList();" multiple>
                     <?php echo genPickList($edahId2Name, array(), "edah"); ?>
                 </select>
             </div>

--- a/chugbot/attendance/chugLeaderHome.php
+++ b/chugbot/attendance/chugLeaderHome.php
@@ -104,7 +104,6 @@ const dd = String(today.getDate()).padStart(2, '0');
 
 const formattedToday = `${yyyy}-${mm}-${dd}`;
 document.getElementById('date').value = formattedToday;
-//console.log(date.getYear()+"-"+(date.getMonth()+1)+"-"+date.getDate());
 
 
 function validateForm() {

--- a/chugbot/attendance/index.php
+++ b/chugbot/attendance/index.php
@@ -1,0 +1,238 @@
+<?php
+include_once '../dbConn.php';
+include_once '../functions.php';
+session_start();
+checkLogout();
+
+// if not admin, redirect to appropriate home page
+if(!adminLoggedIn()) {
+    if(roshLoggedIn()) {
+        $roshUrl = urlIfy("../attendance/roshHome.php");
+        header("Location: $roshUrl");
+        exit();
+    }
+    else if(chugLeaderLoggedIn()) {
+        $chugLeaderUrl = urlIfy("../attendance/chugLeaderHome.php");
+        header("Location: $chugLeaderUrl");
+        exit();
+    }
+    else if(camperLoggedIn()) {
+        $camperUrl = urlIfy("../camperHome.php");
+        header("Location: $camperUrl");
+        exit();
+    }
+    else {
+        $baseUrl = baseUrl();
+        header("Location: $baseUrl");
+        exit();
+    }
+}
+
+
+$dbErr = "";
+$sessionId2Name = array();
+$blockId2Name = array();
+$groupId2Name = array();
+$edahId2Name = array();
+$chugId2Name = array();
+$bunkId2Name = array();
+$group2ActiveBlock = array();
+
+fillId2Name(null, $chugId2Name, $dbErr, "chug_id", "chugim", "group_id", "chug_groups");
+fillId2Name(null, $sessionId2Name, $dbErr, "session_id", "sessions");
+fillId2Name(null, $blockId2Name, $dbErr, "block_id", "blocks");
+fillId2Name(null, $groupId2Name, $dbErr, "group_id", "chug_groups");
+fillId2Name(null, $edahId2Name, $dbErr, "edah_id", "edot");
+fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
+
+
+setup_camp_specific_terminology_constants();
+
+echo headerText("Attendance Admin");
+
+// update saved attendance
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // determine what is being updated/set
+    if(test_post_input("form") == "active-blocks") {
+        $localErr = "";
+        $dbc = new DbConn();
+        // list of applicable chug group ids
+        $groupIds = array_keys($groupId2Name);
+
+        // build SQL
+        $anySet = FALSE;
+        $sql = "UPDATE chug_groups SET active_block_id = ( CASE ";
+        foreach($groupIds as $id) {
+            $block = test_post_input($id);
+            if (!empty($block)) {
+                $sql .= "WHEN (group_id = $id) THEN $block ";
+                $anySet = TRUE;
+            }
+        }
+        $sql .= "ELSE (NULL) END )";
+        // if all are set to null, override built SQL and just clear column
+        if(!$anySet) {
+            $sql = "UPDATE chug_groups SET active_block_id = NULL";
+
+        }
+        
+        // run query
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+        else {
+            $successMessage = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-success alert-dismissible fade show m-2\" role=\"alert\">" . 
+            "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5>Active " . ucfirst(block_term_plural) .
+            " Successfully Updated</h5>People taking and viewing attendance will now see the " . chug_term_singular . " for the newly set " . block_term_plural . "</div></div>";
+            echo $successMessage;
+    
+        }
+        
+    }
+    else if (test_post_input("form") == "purge") {
+        // delete old records
+
+        // 1: verify date is valid form
+        $dateInput = test_post_input("date");
+        $fullDate = strtotime($dateInput);
+        $date = date('Y-m-d', $fullDate);
+        if($fullDate == "") {
+            echo "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+            "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+            "Invalid Date</h5>An invalid date was provided. Please try again to purge old attendance records</div></div>";
+            exit();
+        }
+        else {
+            // 2: do deletions
+            $localErr = "";
+            $dbc = new DbConn();
+            // delete attendance record
+            $sql = "DELETE FROM attendance_present WHERE date < '$date'";
+            $result = $dbc->doQuery($sql, $localErr);
+            if ($result == false) {
+                echo dbErrorString($sql, $localErr);
+                exit();
+            }
+            // delete that attendance was taken for that perek
+            $sql = "DELETE FROM chug_attendance_taken WHERE date < '$date'";
+            $result = $dbc->doQuery($sql, $localErr);
+            if ($result == false) {
+                echo dbErrorString($sql, $localErr);
+                exit();
+            }
+            // show success message
+            $successMessage = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-success alert-dismissible fade show m-2\" role=\"alert\">" . 
+            "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5>Old Attendance Records Successfully Purged</h5>" .
+            "The earliest day with saved attendance records is <strong>" . date("D F j, Y", strtotime($date)) . "</strong></div></div>";
+            echo $successMessage;
+        }
+    }
+}
+
+// get current chug group - active block matches
+$db = new dbConn();
+$db->addSelectColumn("group_id");
+$db->addSelectColumn("active_block_id");
+$result = $db->simpleSelectFromTable("chug_groups", $err);
+if ($result == false) {
+    echo dbErrorString($sql, $localErr);
+    exit();
+}
+while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+    // row[0] is chug group id, row[1] is active block id
+    // genPickList (used below) pre-selects options based on if the key (block id) maps to a value; pass in array corresponding to that group
+    $group2ActiveBlock[$row[0]] = array($row[1]=>$row[1]);
+}
+
+?>
+
+<div class="card card-body mt-3 mb-3 container">
+<h1><a>Welcome</a></h1>
+<div class="page-header">
+<h2>Chug Attendance Admin Page</h3>
+</div>
+
+
+    <form class="card card-body bg-light mb-3" id="assign_active_block_form" method="POST" action=""><ul>
+        <h5>Assign Active <?php echo ucfirst(block_term_plural);?></h5>
+        <p>Campers have different <?php echo chug_term_singular;?> assignments during different parts of the summer. To use the attendance system, 
+        administrators are responsible for assigning the current <?php echo block_term_singular;?> for each <?php echo chug_term_singular;?> perek. 
+        Use the dropdowns below to assign which <?php echo block_term_singular;?> is active. This determines which campers the <?php echo chug_term_singular;?> 
+        leaders will see when taking attendance, as well as the assignments a Rosh/Yoetzet will see when reviewing it.</p>
+        <p>Not selecting a <?php echo block_term_singular;?> (or setting it to <code>-- Choose <?php echo ucfirst(block_term_singular);?> --</code>) for a perek 
+        makes the <?php echo chug_term_singular;?> unavailable for taking/reviewing attendance.</p>
+        <p>Leaving every <?php echo chug_term_singular;?> perek unset disables the attendance system for <?php echo chug_term_singular;?> leaders and Roshes/Yoetzot.</p>
+        <?php 
+        // create a dropdown menu for each chug group to designate which block should be the active one
+        foreach($groupId2Name as $id => $group) {
+            $groupBlockStr  = "<li><label class=\"description\" for=\"group$id\">$group</label>";
+            $groupBlockStr .= "<div id=\"group{$id}_select\" class=\"pb-2\"><select class=\"form-select\" id=\"group$id\" name=\"$id\">";
+            $groupBlockStr .= genPickList($blockId2Name, $group2ActiveBlock[$id], block_term_singular);
+            $groupBlockStr .= "</select></div></li>";
+            echo $groupBlockStr;
+        }
+        ?>
+        <li>
+            <button class="btn btn-success" type="submit" id="submit_btn" name="form" value="active-blocks">Save Active <?php echo ucfirst(block_term_plural);?></button>
+        </li>
+    </ul></form>
+
+    <form class="card card-body bg-light" id="purge_records_form" method="POST" action=""><ul>
+        <h5>Purge Old Attendance Records</h5>
+        <p>If historical attendance records are no longer needed, you can delete all records before a provided date (not inclusive - records will be kept for the day submitted below, but not before).</p>
+        <p><strong style="color:red;">Warning:</strong> once this is submitted, it cannot be undone. Purged attendance records cannot be recovered.</p>
+        <li>
+            <label class="description" for="date"><span style="color:red;">*</span>Delete Attendance Records Before:</label>
+            <div id="date_pick" class="pb-2">
+                <input type="date" id="date" name="date" class="form-control medium" onchange="dateChanged()" required>
+            </div>
+        </li>
+        <li>
+            <button id="purge-modal-btn" type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#purgeModal" disabled>Purge</button>
+        </li>
+    </form>
+</div>
+
+
+<div class="modal fade" id="purgeModal" tabindex="-1" aria-labelledby="purgeModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-warning">
+        <h5 class="modal-title fs-5" id="purgeModalLabel">Warning</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to purge attendance records before <strong id="purge-date-modal" style="color:red"></strong>? There is no way to undo this action.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button id="modal-submit" type="submit" class="btn btn-danger" form="purge_records_form" value="purge" name="form" disabled>Yes, I'm Sure - Delete Records</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+// when date is changed in the date picker, enable "purge" functions - activate the warning button and submit button, and
+// autofill confirmation window with the date which will have everything before it deleted
+function dateChanged() {
+    document.getElementById("purge-modal-btn").disabled = true;
+    document.getElementById("modal-submit").disabled = true;
+    var date = new Date(document.getElementById("date").value + 'T00:00:00');
+    if(date != "Invalid Date") {
+        document.getElementById("purge-modal-btn").disabled = false;
+        document.getElementById("purge-date-modal").innerHTML = date.toLocaleDateString("en-us", { weekday:"long", year:"numeric", month:"short", day:"numeric"});
+        document.getElementById("modal-submit").disabled = false;
+    }
+}
+
+</script>
+
+<?php
+echo footerText();
+?>
+
+</body>
+</html>

--- a/chugbot/attendance/index.php
+++ b/chugbot/attendance/index.php
@@ -108,14 +108,14 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             // 2: do deletions
             $localErr = "";
             $dbc = new DbConn();
-            // delete attendance record
-            $sql = "DELETE FROM attendance_present WHERE date < '$date'";
+            // 2a: delete attendance records
+            $sql = "DELETE FROM attendance WHERE date < '$date'";
             $result = $dbc->doQuery($sql, $localErr);
             if ($result == false) {
                 echo dbErrorString($sql, $localErr);
                 exit();
             }
-            // delete that attendance was taken for that perek
+            // 2b: delete that attendance was taken for that perek
             $sql = "DELETE FROM chug_attendance_taken WHERE date < '$date'";
             $result = $dbc->doQuery($sql, $localErr);
             if ($result == false) {

--- a/chugbot/attendance/roshHome.php
+++ b/chugbot/attendance/roshHome.php
@@ -2,7 +2,7 @@
     session_start();
     include_once '../dbConn.php';
     include_once '../functions.php';
-    bounceToLogin("chug leader");
+    bounceToLogin("rosh");
     checkLogout();
     setup_camp_specific_terminology_constants();
 
@@ -21,8 +21,7 @@
     fillId2Name(null, $edahId2Name, $dbErr, "edah_id", "edot");
     fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
 
-    echo headerText(ucfirst(chug_term_singular) . " Leader Home");
-
+    echo headerText("Rosh Home");
 ?>
     <!-- Uses choices-js, more info at https://github.com/Choices-js/Choices -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
@@ -36,7 +35,7 @@
                     shouldSort: false,
                     allowHTML: true,
                     searchChoices: false,
-                    removeItemButton: true,
+                    removeItemButton: true
                 });
             });
         });
@@ -45,12 +44,12 @@
 <div class="container row justify-content-center" style="margin:auto;"><div id="errors" class="mt-2"></div></div>
 
 <div class="card card-body mt-2 p-3 mb-3 container">
-    <h1><?php echo ucfirst(chug_term_singular)?> Leader Home</h1>
-    <div class="page-header"><h2><?php echo ucfirst(chug_term_singular)?> Leader Home</h2>
-    <p>In the form below, select the date, edah/edot, perek, and <?php echo chug_term_singular?> you are taking attendance for.
-    After clicking "Take Attendance" below the form, check the box for each camper who is <strong>present</strong>. Then press "Submit attendance" to complete the attendance.</p>
+    <h1>Rosh Edah/Yoetzet Home</h1>
+    <div class="page-header"><h2>Rosh Edah/Yoetzet Home</h2>
+    <p>In the form below, select the date, edah, and perek you wish to review attendance records for.
+    Just click "View Attendance" below the form to see the latest record.</p>
     
-    <form id="attendance_chug_select_form" class="justify-content-center" method="GET" action="takeAttendance.php" onsubmit="return validateForm()"><ul>
+    <form id="attendance_chug_select_form" class="justify-content-center" method="GET" action="viewAttendance.php" onsubmit="return validateForm()"><ul>
         <li style="margin:auto;" class="ps-0">
             <label class="description" for="date"><span style="color:red;">*</span>Date</label>
             <div id="date_pick" class="pb-2">
@@ -58,9 +57,9 @@
             </div>
         </li>
         <li style="margin:auto;" class="ps-0">
-            <label class="description" for="edah[]"><span style="color:red;">*</span>Edah/Edot</label>
+            <label class="description" for="edah"><span style="color:red;">*</span>Edah/Edot</label>
             <div id="edah_select" class="pb-2">
-                <select class="form-select bg-info choices-js" id="edah_list" name="edah[]" onchange="fillConstraintsPickList(); fillChugimConstraintsPickList();" multiple>
+                <select class="form-select bg-info choices-js" id="edah_list" name="edah[]" onchange="fillConstraintsPickList();" multiple>
                     <?php echo genPickList($edahId2Name, array(), "edah"); ?>
                 </select>
             </div>
@@ -71,15 +70,9 @@
                 <?php echo genConstrainedPickListScript("group_select", "edah", "group_desc", "group", true); ?>
             </div>
         </li>
-        <li style="margin:auto;" class="ps-0">
-            <label class="description" for="chug" id="chug_desc"><span style="color:red;">*</span><?php echo ucfirst(chug_term_singular) ?></label>
-            <div id="chug_select" class="pb-2">
-                <?php echo genChugimPickListScript("chug_select", "edah", "group", "chug_desc", "chug", true); ?>
-            </div>
-        </li>
         <li style="margin:auto;">
             <div class="row justify-content-center">
-                <div class="col-6" style="text-align:center;"><button class="btn btn-primary" type="submit" id="submit_btn">Take Attendance</button></div>
+                <div class="col-6" style="text-align:center;"><button class="btn btn-primary" type="submit" id="submit_btn">View Attendance</button></div>
             </div>
         </li>
     </ul></form>
@@ -88,14 +81,7 @@
 
 <script>
 // automatically set date to "today"
-const today = new Date();
-const yyyy = today.getFullYear();
-const mm = String(today.getMonth() + 1).padStart(2, '0'); // Months start at 0!
-const dd = String(today.getDate()).padStart(2, '0');
-
-const formattedToday = `${yyyy}-${mm}-${dd}`;
-document.getElementById('date').value = formattedToday;
-//console.log(date.getYear()+"-"+(date.getMonth()+1)+"-"+date.getDate());
+document.getElementById('date').valueAsDate = new Date();
 
 
 function validateForm() {
@@ -106,7 +92,7 @@ function validateForm() {
     let valid = true;
 
     // ensure each required field is filled out - first check field exists, then that it has a value
-    fields = ["date", "edah[]", "group", "chug"];
+    fields = ["date", "edah[]", "group"];
     fields.forEach((field) => {
         let x = document.forms["attendance_chug_select_form"][field];
         if(field === "group") { field = "perek"; } // small override to keep backend and UI consistent with each other

--- a/chugbot/attendance/roshHome.php
+++ b/chugbot/attendance/roshHome.php
@@ -155,7 +155,13 @@
 
 <script>
 // automatically set date to "today"
-document.getElementById('date').valueAsDate = new Date();
+const today = new Date();
+const yyyy = today.getFullYear();
+const mm = String(today.getMonth() + 1).padStart(2, '0'); // Months start at 0!
+const dd = String(today.getDate()).padStart(2, '0');
+
+const formattedToday = `${yyyy}-${mm}-${dd}`;
+document.getElementById('date').value = formattedToday;
 
 
 function validateAttendanceForm() {

--- a/chugbot/attendance/roshHome.php
+++ b/chugbot/attendance/roshHome.php
@@ -54,37 +54,102 @@
 
 <div class="card card-body mt-2 p-3 mb-3 container">
     <h1>Rosh Edah/Yoetzet Home</h1>
-    <div class="page-header"><h2>Rosh Edah/Yoetzet Home</h2>
-    <p>In the form below, select the date, edah, and perek you wish to review attendance records for.
-    Just click "View Attendance" below the form to see the latest record.</p>
-    
-    <form id="attendance_chug_select_form" class="justify-content-center" method="GET" action="viewAttendance.php" onsubmit="return validateForm()"><ul>
-        <li style="margin:auto;" class="ps-0">
-            <label class="description" for="date"><span style="color:red;">*</span>Date</label>
-            <div id="date_pick" class="pb-2">
-                <input type="date" id="date" name="date" class="form-control medium" required>
+    <div class="page-header mb-3"><h2>Rosh Edah/Yoetzet Home</h2>
+        Below, choose to review detailed attendance records for one particular perek on a given day, or view the attendance matrix over a specified time frame.
+        <ul>
+            <li>If quickly checking attendance for your edah, utilize <strong>Attendance by Date</strong></li>
+            <li>If exploring attendance trends over time, look at <strong>Attendance Matrix</strong></li>
+        </ul>
+    </div>
+
+    <div class="accordion" id="viewAttendanceAccordion">
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="headingSingle">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSingle" aria-expanded="true" aria-controls="collapseSingle">
+                Attendance by Date
+            </button>
+        </h2>
+        <div id="collapseSingle" class="accordion-collapse collapse show" aria-labelledby="headingSingle" data-bs-parent="#viewAttendanceAccordion">
+            <div class="accordion-body">
+                <p>In the form below, select the date, edah, and perek you wish to review attendance records for.
+                Just click "View Attendance" below the form to see the latest record.</p>
+                
+                <form id="attendance_chug_select_form" class="justify-content-center" method="GET" action="viewAttendance.php" onsubmit="return validateAttendanceForm()"><ul>
+                    <li style="margin:auto;" class="ps-0">
+                        <label class="description" for="date"><span style="color:red;">*</span>Date</label>
+                        <div id="date_pick" class="pb-2">
+                            <input type="date" id="date" name="date" class="form-control medium" required>
+                        </div>
+                    </li>
+                    <li style="margin:auto;" class="ps-0">
+                        <label class="description" for="edah"><span style="color:red;">*</span>Edah/Edot</label>
+                        <div id="edah_select" class="pb-2">
+                            <select class="form-select bg-info choices-js" id="edah_list" name="edah[]" onchange="fillConstraintsPickList();" multiple>
+                                <?php echo genPickList($edahId2Name, array(), "edah"); ?>
+                            </select>
+                        </div>
+                    </li>
+                    <li style="margin:auto;" class="ps-0"> 
+                        <label class="description" for="group" id="group_desc"><span style="color:red;">*</span>Perek</label>
+                        <div id="group_select" class="pb-2">
+                            <?php echo genConstrainedPickListScript("group_select", "edah", "group_desc", "group", true); ?>
+                        </div>
+                    </li>
+                    <li style="margin:auto;">
+                        <div class="row justify-content-center">
+                            <div class="col-6" style="text-align:center;"><button class="btn btn-primary" type="submit" id="submit_btn">View Attendance</button></div>
+                        </div>
+                    </li>
+                </ul></form>
             </div>
-        </li>
-        <li style="margin:auto;" class="ps-0">
-            <label class="description" for="edah"><span style="color:red;">*</span>Edah/Edot</label>
-            <div id="edah_select" class="pb-2">
-                <select class="form-select bg-info choices-js" id="edah_list" name="edah[]" onchange="fillConstraintsPickList();" multiple>
-                    <?php echo genPickList($edahId2Name, array(), "edah"); ?>
-                </select>
+        </div>
+    </div>
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="headingAdmin">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAdmin" aria-expanded="false" aria-controls="collapseAdmin">
+                Attendance Matrix
+            </button>
+        </h2>
+        <div id="collapseAdmin" class="accordion-collapse collapse" aria-labelledby="headingAdmin" data-bs-parent="#viewAttendanceAccordion">
+            <div class="accordion-body">
+                Select the beginning and ending dates (inclusive) you wish to review the attendance records for, and select the edah you are checking. Then, press "View Attendance Matrix" below the form to see the attendance trends.<br>
+                <strong>Note:</strong> it is NOT recommended to view this page on a mobile device - computers or tablets are highly recommended for viewing the attendance matrix
+
+                <form id="attendance_matrix_form" class="justify-content-center mt-4" method="GET" action="viewAttendanceMatrix.php" onsubmit="return validateMatrixForm()"><ul>
+                    <li style="margin:auto;" class="ps-0">
+                        <div class="row">
+                            <div class="col">
+                                <label class="description" for="start-date"><span style="color:red;">*</span>Start Date (inclusive)</label>
+                                <div id="date_pick" class="pb-2 ps-2">
+                                    <input type="date" id="start-date" name="start-date" class="form-control">
+                                </div>
+                            </div>
+                            <div class="col">
+                                <label class="description" for="end-date"><span style="color:red;">*</span>End Date (inclusive)</label>
+                                <div id="date_pick" class="pb-2">
+                                    <input type="date" id="end-date" name="end-date" class="form-control">
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li style="margin:auto;" class="ps-0">
+                        <label class="description" for="edah"><span style="color:red;">*</span>Edah/Edot</label>
+                        <div id="edah_select" class="pb-2">
+                            <select class="form-select bg-info choices-js" id="edah_list" name="edah">
+                                <?php echo genPickList($edahId2Name, array(), "edah"); ?>
+                            </select>
+                        </div>
+                    </li>
+                    <li style="margin:auto;">
+                        <div class="row justify-content-center mt-2">
+                            <div class="col-6" style="text-align:center;"><button class="btn btn-primary" type="submit" id="submit_btn">View Attendance Matrix</button></div>
+                        </div>
+                    </li>
+                </ul></form>
             </div>
-        </li>
-        <li style="margin:auto;" class="ps-0"> 
-            <label class="description" for="group" id="group_desc"><span style="color:red;">*</span>Perek</label>
-            <div id="group_select" class="pb-2">
-                <?php echo genConstrainedPickListScript("group_select", "edah", "group_desc", "group", true); ?>
-            </div>
-        </li>
-        <li style="margin:auto;">
-            <div class="row justify-content-center">
-                <div class="col-6" style="text-align:center;"><button class="btn btn-primary" type="submit" id="submit_btn">View Attendance</button></div>
-            </div>
-        </li>
-    </ul></form>
+        </div>
+    </div>
+    </div>
 
 </div>
 
@@ -93,7 +158,7 @@
 document.getElementById('date').valueAsDate = new Date();
 
 
-function validateForm() {
+function validateAttendanceForm() {
     var error = "<div class=\"alert alert-danger alert-dismissible fade show mb-0 ms-2 me-2\" role=\"alert\">";
     error += "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button>";
     error += "<h5><strong>Error:</strong> Not all required fields are complete</h5><ul class=\"mb-0\">";
@@ -120,6 +185,57 @@ function validateForm() {
             }
         }
     });
+
+    error += "</ul></div>";    
+
+    if(!valid) {
+        // if form is not ready to submit, show errors and cancel submission
+        var errorDiv = document.getElementById("errors");
+        errorDiv.innerHTML = error;
+        return false;
+    }
+    else {
+        // an extra field (a "search term") is being submitted because of the dropdown; this disables that
+        const cloned = document.getElementsByClassName("choices__input--cloned");
+        cloned[0].setAttribute('disabled', 'true');
+        cloned[1].setAttribute('disabled', 'true');
+        // then just automatically submits!
+    }
+}
+
+function validateMatrixForm() {
+    var error = "<div class=\"alert alert-danger alert-dismissible fade show mb-0 ms-2 me-2\" role=\"alert\">";
+    error += "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button>";
+    error += "<h5><strong>Error:</strong> Not all required fields are complete</h5><ul class=\"mb-0\">";
+
+    let valid = true;
+
+    // ensure each required field is filled out - first check field exists, then that it has a value
+    fields = ["start-date", "end-date", "edah"];
+    fields.forEach((field) => {
+        console.log(field);
+        let x = document.forms["attendance_matrix_form"][field];
+        field = field.replace("-", " "); // small change to remove hyphen from field name for UI
+        // check field exists
+        if(x === undefined) {
+            error += "<li><strong>"+field[0].toUpperCase() + field.slice(1)+"</strong> missing</li>";
+            valid = false;
+        }
+        else {
+            // check field has value
+            x = x.value;
+            if (x == "") {
+                error += "<li><strong>"+field[0].toUpperCase() + field.slice(1)+"</strong> missing</li>";
+                valid = false;
+            }
+        }
+    });
+
+    // ensure end date is after start date
+    if (new Date(document.forms["attendance_matrix_form"]['start-date'].value) > new Date(document.forms["attendance_matrix_form"]['end-date'].value)) {
+        error += "<li><strong>Start Date</strong> is after <strong>End Date</strong> -- start date must be earlier</li>";
+        valid = false;
+    }
 
     error += "</ul></div>";    
 

--- a/chugbot/attendance/roshHome.php
+++ b/chugbot/attendance/roshHome.php
@@ -22,6 +22,15 @@
     fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
 
     echo headerText("Rosh Home");
+
+    if(!attendanceActive()) {
+        $fullErrorMsg = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+        "Attendance Disabled</h5>Nothing is available to take attendance for; attendance has been disabled. " .
+        "Contact an administrator if you believe to be receiving this message in error.</div></div>";
+        echo $fullErrorMsg;
+        exit();
+    }
 ?>
     <!-- Uses choices-js, more info at https://github.com/Choices-js/Choices -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
@@ -53,7 +62,7 @@
         <li style="margin:auto;" class="ps-0">
             <label class="description" for="date"><span style="color:red;">*</span>Date</label>
             <div id="date_pick" class="pb-2">
-                <input type="date" id="date" name="date" class="form-control medium">
+                <input type="date" id="date" name="date" class="form-control medium" required>
             </div>
         </li>
         <li style="margin:auto;" class="ps-0">
@@ -131,3 +140,18 @@ function validateForm() {
 </script>
 
 </body>
+
+<?php
+function attendanceActive() {
+    $db = new dbConn();
+    $dbErr = "";
+    $db->addSelectColumn("count(active_block_id)");
+    $result = $db->simpleSelectFromTable("chug_groups", $dbErr);
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+        // just gets the count of active blocks
+        return $row[0] > 0;
+    }
+    return false;
+}
+
+?>

--- a/chugbot/attendance/takeAttendance.php
+++ b/chugbot/attendance/takeAttendance.php
@@ -52,29 +52,41 @@
         while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
             $chugInstanceId = $row[0]; // the only thing being returned by this statement is the chug instance id
         }
-        // 2: delete all attendance records for this chug instance for specified day
-        $localErr = "";
-        $dbc = new DbConn();
-        $sql = "DELETE FROM attendance_present WHERE chug_instance_id = $chugInstanceId AND date='$date'";
-        $result = $dbc->doQuery($sql, $localErr);
-        if ($result == false) {
-            echo dbErrorString($sql, $localErr);
-            exit();
+
+        $presentCamperCount = $absentCamperCount = 0;
+        if(test_post_input('absent') != "") {
+            $absentCamperCount = count($_POST['absent']);
+        }
+        if(test_post_input('present') != "") {
+            $presentCamperCount = count($_POST['present']);
         }
 
-        // 3: build sql statement adding each camper id to be inserted
-        if(test_post_input('attendance') != "") {
+        // 2: build sql statement updating attendance for each camper
+        if($presentCamperCount + $absentCamperCount > 0) {
             $localErr = "";
             $dbc = new DbConn();
-            $sql = "INSERT INTO attendance_present (camper_id, date, chug_instance_id) VALUES ";
-            $ct = 1;            
-            foreach($_POST['attendance'] as $camper) {
-                $sql .= "($camper, '$date', $chugInstanceId)";
-                // add a comma between every value
-                if($ct++ < count($_POST['attendance'])) {
-                    $sql .= ",";
+            $sql = "REPLACE INTO attendance (camper_id, date, chug_instance_id, present) VALUES ";
+            $ct = 1;
+            // present campers
+            if($presentCamperCount > 0) {
+                foreach($_POST['present'] as $camper) {
+                    $sql .= "($camper, '$date', $chugInstanceId, 1)";
+                    // add a comma between every value
+                    if($ct++ < $presentCamperCount + $absentCamperCount) {
+                        $sql .= ",";
+                    }
                 }
             }
+            // absent campers
+            if($absentCamperCount > 0) {
+                foreach($_POST['absent'] as $camper) {
+                    $sql .= "($camper, '$date', $chugInstanceId, 0)";
+                    // add a comma between every value
+                    if($ct++ < $presentCamperCount + $absentCamperCount) {
+                        $sql .= ",";
+                    }
+                }
+            }   
             $result = $dbc->doQuery($sql, $localErr);
             if ($result == false) {
                 echo dbErrorString($sql, $localErr);
@@ -82,29 +94,36 @@
             }
         }
 
-        // 4: note that attendance has been taken for this perek on this day
-        if(test_post_input('attendance') != "") {
+        // 3: update date <-> group <-> block relationship in database
+        if($presentCamperCount + $absentCamperCount > 0) {
+            // get active block id for current group
             $localErr = "";
             $dbc = new DbConn();
-            $sql = "INSERT IGNORE INTO chug_attendance_taken (edah_id, date, chug_instance_id) VALUES ";
-            $ct = 1; 
-            foreach($edahIds as $id) {
-                $sql .= "($id, '$date', $chugInstanceId)";
-                // add a comma between every value
-                if($ct++ < count($edahIds)) {
-                    $sql .= ",";
-                }
-            }
+            $sql = "SELECT active_block_id FROM chug_groups WHERE group_id = $groupId";
             $result = $dbc->doQuery($sql, $localErr);
             if ($result == false) {
                 echo dbErrorString($sql, $localErr);
                 exit();
+            }
+            $activeBlockId = NULL;
+            while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+                $activeBlockId = $row[0]; // only thing being returned
+            }
+            if($activeBlockId != NULL) {
+                $localErr = "";
+                $dbc = new DbConn();
+                $sql = "REPLACE INTO attendance_block_by_date (date, group_id, block_id) VALUES ('$date', $groupId, $activeBlockId)";
+                $result = $dbc->doQuery($sql, $localErr);
+                if ($result == false) {
+                    echo dbErrorString($sql, $localErr);
+                    exit();
+                }
             }
         }
 
         $successMessage = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-success alert-dismissible fade show m-2\" role=\"alert\">" . 
         "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Congrats!</strong> " . 
-        "Attendance Successfully Submitted</h5>The attendance records have been saved. You can now safely close this page, or update the attendance below.</div>";
+        "Attendance Successfully Submitted</h5>The attendance records have been saved. You can now safely close this page, or update the attendance below.</div></div>";
         echo $successMessage;
     }
 ?>
@@ -124,12 +143,12 @@
         $localErr = "";
         $dbc = new DbConn();
         // this sql statement gets all matches, camper names, ids, and bunks
-        $sql = "SELECT c.camper_id, CONCAT(c.last, ', ', c.first) AS name, b.name AS bunk, a.attendance_id IS NOT NULL AS is_present FROM campers c " .
+        $sql = "SELECT c.camper_id, CONCAT(c.last, ', ', c.first) AS name, b.name AS bunk, a.present AS is_present FROM campers c " .
             "JOIN matches m ON c.camper_id = m.camper_id JOIN chug_instances i ON m.chug_instance_id = i.chug_instance_id " . 
             "JOIN chugim ch ON i.chug_id = ch.chug_id JOIN bunks b ON c.bunk_id = b.bunk_id " . 
             "JOIN chug_groups g on ch.group_id = g.group_id ";
         // include attendance record
-        $sql .= "LEFT OUTER JOIN (SELECT * FROM attendance_present WHERE date = '" . $date . "') a ON c.camper_id = a.camper_id AND i.chug_instance_id = a.chug_instance_id ";
+        $sql .= "LEFT OUTER JOIN (SELECT * FROM attendance WHERE date = '" . $date . "') a ON c.camper_id = a.camper_id AND i.chug_instance_id = a.chug_instance_id ";
         // narrow it down by edah, chug, block, and only show "active" campers
         $sql .= "WHERE c.edah_id = " . $edahId . " AND c.inactive = 0 AND ch.chug_id = " . $chugId . " AND i.block_id = g.active_block_id ";
         // sort by bunk, then last name
@@ -157,7 +176,7 @@
                 $selected = "checked=checked";
             }
             $att .= "<label class=\"form-check-label\"><input class=\"form-check-input ms-2 me-1 att-child\" type=\"checkbox\"" .  
-                    "name=\"attendance[]\" value=\"${row[0]}\" id=\"\" $selected>$row[1]</label>";
+                    "name=\"present[]\" value=\"${row[0]}\" id=\"\" $selected>$row[1]</label>";
         }
 
         $attendanceSection = "<div class=\"card card-body bg-light mt-3 mb-3 edah-attendance\">";
@@ -187,6 +206,31 @@
                 checkbox.checked = source.checked;
             }
         }
+
+        // create additional form item for all campers who are NOT present
+        document.getElementById('attendance_chug_select_form').addEventListener('submit', function(event) {
+            // Get all checkboxes
+            const checkboxes = document.querySelectorAll('input[type="checkbox"][name="present[]"]');
+            // Create an array to store values of unchecked checkboxes
+            let uncheckedValues = [];
+
+            // Loop through each checkbox
+            checkboxes.forEach(checkbox => {
+                // If the checkbox is not checked, add its value to the array
+                if (!checkbox.checked) {
+                    uncheckedValues.push(checkbox.value);
+                }
+            });
+
+            // Create hidden inputs for unchecked values
+            uncheckedValues.forEach(value => {
+                let hiddenInput = document.createElement('input');
+                hiddenInput.type = 'hidden';
+                hiddenInput.name = 'absent[]';
+                hiddenInput.value = value;
+                this.appendChild(hiddenInput);
+            });
+        });
     </script>
 </div>
 </body>

--- a/chugbot/attendance/takeAttendance.php
+++ b/chugbot/attendance/takeAttendance.php
@@ -1,0 +1,233 @@
+<?php
+    session_start();
+    include_once '../dbConn.php';
+    include_once '../functions.php';
+    bounceToLogin();
+    setup_camp_specific_terminology_constants();
+
+    $dbErr = "";
+    $sessionId2Name = array();
+    $blockId2Name = array();
+    $groupId2Name = array();
+    $edahId2Name = array();
+    $chugId2Name = array();
+    $bunkId2Name = array();
+
+    fillId2Name(null, $chugId2Name, $dbErr, "chug_id", "chugim", "group_id", "chug_groups");
+    fillId2Name(null, $sessionId2Name, $dbErr, "session_id", "sessions");
+    fillId2Name(null, $blockId2Name, $dbErr, "block_id", "blocks");
+    fillId2Name(null, $groupId2Name, $dbErr, "group_id", "chug_groups");
+    fillId2Name(null, $edahId2Name, $dbErr, "edah_id", "edot");
+    fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
+
+    echo headerText(ucfirst(chug_term_singular) . " Leader Home");
+
+    // Get info from the form
+    $date = test_get_input('date');
+    $groupId = test_get_input('group');
+    $chugId = test_get_input('chug');
+    $rawEdahIds = test_input($_GET['edah']);
+    $edahIds = [];
+
+    // additional function (at bottom of code) to ensure everything was properly formatted and valid values
+    // were passed in
+    validate_form_inputs();
+
+    // update saved attendance
+    if ($_SERVER["REQUEST_METHOD"] == "POST") {
+        // 1: get chug_instance_id (block is known (based on active_block_id, using group_id), chug_id is know)
+        $localErr = "";
+        $dbc = new DbConn();
+        $sql = "SELECT chug_instance_id FROM chug_instances i JOIN chug_groups g ON i.block_id = g.active_block_id WHERE i.chug_id = $chugId and g.group_id = $groupId";
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+        $chugInstanceId;
+        while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+            $chugInstanceId = $row[0]; // the only thing being returned by this statement is the chug instance id
+        }
+        // 2: delete all attendance records for this chug instance for specified day
+        $localErr = "";
+        $dbc = new DbConn();
+        $sql = "DELETE FROM attendance_present WHERE chug_instance_id = $chugInstanceId AND date='$date'";
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+
+        // 3: build sql statement adding each camper id to be inserted
+        $localErr = "";
+        $dbc = new DbConn();
+        $sql = "INSERT INTO attendance_present (camper_id, date, chug_instance_id) VALUES ";
+        $ct = 1;
+        foreach($_POST['attendance'] as $camper) {
+            $sql .= "($camper, '$date', $chugInstanceId)";
+            // add a comma between every value
+            if($ct++ < count($_POST['attendance'])) {
+                $sql .= ",";
+            }
+        }
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+
+        $successMessage = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-success alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Congrats!</strong> " . 
+        "Attendance Successfully Submitted</h5>The attendance records have been saved. You can now safely close this page, or update the attendance below.</div>";
+        echo $successMessage;
+    }
+?>
+
+<div class="card card-body mt-2 p-3 mb-3 container">
+    <h1>Take Attendance</h1>
+    <div class="page-header"><h2>Attendance for <?php echo $chugId2Name[$chugId]; ?></h2>
+    <h4> Date: <?php echo $date; ?> </h4>
+    Select all campers who are <strong>present</strong>, and then press "Submit Attendance" at the bottom of the page to save.
+    </div>
+
+    <form id="attendance_chug_select_form" class="justify-content-center" method="POST" action="">
+
+    <?php 
+    foreach($edahIds as $edahId) {
+        // Step 1: SQL to determine which campers (in specified edah) are in the chug
+        $localErr = "";
+        $dbc = new DbConn();
+        // this sql statement gets all matches, camper names, ids, and bunks
+        $sql = "SELECT c.camper_id, CONCAT(c.last, ', ', c.first) AS name, b.name AS bunk, a.attendance_id IS NOT NULL AS is_present FROM campers c " .
+            "JOIN matches m ON c.camper_id = m.camper_id JOIN chug_instances i ON m.chug_instance_id = i.chug_instance_id " . 
+            "JOIN chugim ch ON i.chug_id = ch.chug_id JOIN bunks b ON c.bunk_id = b.bunk_id " . 
+            "JOIN chug_groups g on ch.group_id = g.group_id ";
+        // include attendance record
+        $sql .= "LEFT OUTER JOIN (SELECT * FROM attendance_present WHERE date = '" . $date . "') a ON c.camper_id = a.camper_id AND i.chug_instance_id = a.chug_instance_id ";
+        // narrow it down by edah, chug, block
+        $sql .= "WHERE c.edah_id = " . $edahId . " AND ch.chug_id = " . $chugId . " AND i.block_id = g.active_block_id ";
+        // sort by bunk, then last name
+        $sql .= " ORDER BY bunk, name ";
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+        
+        $att = "";
+        $bunk = "";
+        while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+            // breakdown of $row:
+                // [0] - camper id
+                // [1] - name 
+                // [2] - bunk
+                // [3] - is_present (already recorded as being present)
+            if($row[2] != $bunk) {
+                $att .= "<p class=\"mb-0\"><strong>Bunk:</strong> $row[2]</p>";
+                $bunk = $row[2];
+            }
+            $selected = "";
+            if($row[3]) { // if camper has already been marked as present, pre-check that box
+                $selected = "checked=checked";
+            }
+            $att .= "<label class=\"form-check-label\"><input class=\"form-check-input ms-2 me-1 att-child\" type=\"checkbox\"" .  
+                    "name=\"attendance[]\" value=\"${row[0]}\" id=\"\" $selected>$row[1]</label>";
+        }
+
+        $attendanceSection = "<div class=\"card card-body bg-light mt-3 mb-3 edah-attendance\">";
+        $attendanceSection .= "<h5>Edah: " . $edahId2Name[$edahId] . "</h5>";
+        $attendanceSection .= "<label><input class=\"form-check-input me-1 mb-2\" type=\"checkbox\" id=\"toggle-all\" onclick=\"toggleCheckboxes(this)\">Toggle All</label>";
+        $attendanceSection .= $att;
+        $attendanceSection .= "</div>";
+        if($att != "") {
+            echo $attendanceSection;
+        }
+    }
+
+    ?>
+    
+    <div class="row justify-content-center"><div class="col-6" style="text-align:center;">
+        <button class="btn btn-success" type="submit" id="submit_btn">Submit Attendance</button>
+    </div></div>
+
+    </form>
+
+
+    <script>
+        function toggleCheckboxes(source) {
+            const container = source.closest('.edah-attendance');
+            const checkboxes = container.querySelectorAll('.att-child');
+            for (let checkbox of checkboxes) {
+                checkbox.checked = source.checked;
+            }
+        }
+    </script>
+</div>
+</body>
+
+<?php 
+function validate_form_inputs()
+{
+    $fullErrorMsg = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+        "Invalid Selections</h5>Return to <a href=\"chugLeaderHome.php\" class=\"alert-link\">previous page</a> to fix following issue(s):<ul class=\"mb-0\">";
+    $errors = "";
+
+    // declare scope of variables
+    global $edahIds, $rawEdahIds, $date, $groupId, $chugId;
+
+    // Step 1: edah ids
+    foreach($rawEdahIds as $i => $id) {
+        $id = trim($id);
+        $id = stripslashes($id);
+        $id = htmlspecialchars($id);
+        $rawEdahIds[$i] = $id;
+    }
+
+    // sort edahIds by proper sort_order
+    $localErr = "";
+    $dbc = new DbConn();
+    $sql = "SELECT edah_id FROM edot ORDER BY sort_order";
+    $result = $dbc->doQuery($sql, $localErr);
+    if ($result == false) {
+        echo dbErrorString($sql, $localErr);
+        exit();
+    }
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+        if(in_array($row[0], $rawEdahIds)) {
+            array_push($edahIds, $row[0]);
+        }
+    }
+    if(count($edahIds) == 0) {
+        $errors .= "<li>Improper edah id(s)</li>";
+    }
+
+
+    // Step 2: date format
+    $fullDate = strtotime($date);
+    $date = date('Y-m-d', $fullDate);
+    if($fullDate == "") {
+        $errors .= "<li>Invalid date</li>";
+    }
+    
+    // Step 3: group id, chug id valid
+    $localErr = "";
+    $dbc = new DbConn();
+    $sql = "SELECT g.group_id, c.chug_id FROM chug_groups g, chugim c WHERE g.group_id = " . intval($groupId) . " AND c.chug_id = " . intval($chugId) . " AND g.active_block_id IS NOT NULL";
+    $result = $dbc->doQuery($sql, $localErr);
+    if ($result == false) {
+        echo dbErrorString($sql, $localErr);
+        exit();
+    }
+    if($result->num_rows != 1) {
+        $errors .= "<li>Chug and/or perek not properly selected</li>";
+    }
+
+    // build/return final error message if necessary
+    if($errors != "") {
+        echo $fullErrorMsg . $errors . "</ul></div></div>";
+        exit();
+    }
+}
+
+?>

--- a/chugbot/attendance/takeAttendance.php
+++ b/chugbot/attendance/takeAttendance.php
@@ -2,7 +2,8 @@
     session_start();
     include_once '../dbConn.php';
     include_once '../functions.php';
-    bounceToLogin();
+    bounceToLogin("chugLeader");
+    checkLogout();
     setup_camp_specific_terminology_constants();
 
     $dbErr = "";
@@ -71,6 +72,26 @@
                 $sql .= "($camper, '$date', $chugInstanceId)";
                 // add a comma between every value
                 if($ct++ < count($_POST['attendance'])) {
+                    $sql .= ",";
+                }
+            }
+            $result = $dbc->doQuery($sql, $localErr);
+            if ($result == false) {
+                echo dbErrorString($sql, $localErr);
+                exit();
+            }
+        }
+
+        // 4: note that attendance has been taken for this perek on this day
+        if(test_post_input('attendance') != "") {
+            $localErr = "";
+            $dbc = new DbConn();
+            $sql = "INSERT IGNORE INTO chug_attendance_taken (edah_id, date, chug_instance_id) VALUES ";
+            $ct = 1; 
+            foreach($edahIds as $id) {
+                $sql .= "($id, '$date', $chugInstanceId)";
+                // add a comma between every value
+                if($ct++ < count($edahIds)) {
                     $sql .= ",";
                 }
             }

--- a/chugbot/attendance/viewAttendance.php
+++ b/chugbot/attendance/viewAttendance.php
@@ -102,19 +102,23 @@
             if(!$row[6] && $row[7]) { // missing, attendance taken
                 $tr .= "table-danger absent";
                 $icon = "<i class=\"bi bi-x-circle-fill\"></i>";
+                $status = "Absent";
             }
             else if ($row[6]) { // present, attendance taken
                 $tr .= "present";
                 $icon = "<i class=\"bi bi-check-circle\"></i>";
+                $status = "Present";
             }
             else { // missing, but attendance not taken
                 $tr .= "table-warning absent";
                 $icon = "<i class=\"bi bi-exclamation-triangle\"></i>";
+                $status = "Attendance not yet taken";
             }
             $tr .= "\">";
 
             // status icon
-            $tr .= "<td class=\"text-center align-middle\">$icon</td>";
+            $tr .= "<td class=\"text-center align-middle\"><span data-bs-toggle=\"tooltip\" data-bs-html=\"true\" title=\"$status\" " . 
+                    "style=\"border-bottom: 1px dashed #999;text-decoration: none; \">$icon</td>";
 
             // bunk
             $tr .= "<td>$row[2]</td>";

--- a/chugbot/attendance/viewAttendance.php
+++ b/chugbot/attendance/viewAttendance.php
@@ -1,0 +1,325 @@
+<?php
+    session_start();
+    include_once '../dbConn.php';
+    include_once '../functions.php';
+    bounceToLogin();
+    setup_camp_specific_terminology_constants();
+
+    $dbErr = "";
+    $sessionId2Name = array();
+    $blockId2Name = array();
+    $groupId2Name = array();
+    $edahId2Name = array();
+    $chugId2Name = array();
+    $bunkId2Name = array();
+
+    fillId2Name(null, $chugId2Name, $dbErr, "chug_id", "chugim", "group_id", "chug_groups");
+    fillId2Name(null, $sessionId2Name, $dbErr, "session_id", "sessions");
+    fillId2Name(null, $blockId2Name, $dbErr, "block_id", "blocks");
+    fillId2Name(null, $groupId2Name, $dbErr, "group_id", "chug_groups");
+    fillId2Name(null, $edahId2Name, $dbErr, "edah_id", "edot");
+    fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
+
+    echo headerText("View Attendance");
+
+    // Get info from the form
+    $date = test_get_input('date');
+    $groupId = test_get_input('group');
+    $rawEdahIds = [];
+    if(test_get_input('edah') != "") {
+        $rawEdahIds = test_input($_GET['edah']);
+    }
+    $edahIds = [];
+
+    // additional function (at bottom of code) to ensure everything was properly formatted and valid values
+    // were passed in
+    validate_form_inputs();
+
+?>
+<script src="https://cdn.jsdelivr.net/npm/@floating-ui/core@1.6.2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.6.5"></script>
+
+<div class="card card-body mt-2 p-3 mb-3 container">
+    <h1>View Attendance</h1>
+    <div class="page-header"><h2><?php echo $groupId2Name[$groupId]; ?> Attendance</h2>
+    <h4> Date: <?php echo $date; ?> </h4>
+    </div>
+
+    <p>By default, all campers are shown, and those who do not have attendance recorded for the designated day are highlighted in red.
+    If a <?php echo chug_term_singular; ?> name is underlined, hover over it (or click if on a mobile device) to see more information.
+    Beneath the report for an edah is a button which copies a plaintext report of missing campers to your clipboard (which can then be easily sent to madrichim).</p>
+    
+    Toggle the switch below to adjust if all campers are shown or only missing ones:
+
+    <div class="form-check form-switch ps-0 fw-bold text-center">
+        <span class="me-1">All Campers</span>
+        <input class="form-check-input ms-0 float-none me-1" type="checkbox" onChange="togglePresent()" id="all_absent_switch">
+        <span class="">Only Absent Campers</span>
+    </div>
+
+    <?php 
+    foreach($edahIds as $edahId) {
+        // Step 1: SQL for all campers, chug assignments, and if they are present or not
+        $localErr = "";
+        $dbc = new DbConn();
+        // this sql statement gets all campers in the edah with their chug assignments
+        $sql = "SELECT c.camper_id, CONCAT(c.last, ', ', c.first) AS name, b.name AS bunk, ch.name AS chug, ch.department_name, ch.rosh_name, a.attendance_id IS NOT NULL AS is_present " .
+            "FROM campers c JOIN matches m ON c.camper_id = m.camper_id " .
+            "JOIN bunks b ON c.bunk_id = b.bunk_id " . 
+            "JOIN chug_instances i ON m.chug_instance_id = i.chug_instance_id " . 
+            "JOIN chugim ch on ch.chug_id = i.chug_id " . 
+            "JOIN chug_groups g on ch.group_id = g.group_id ";
+        // include attendance record
+        $sql .= "LEFT OUTER JOIN (SELECT * FROM attendance_present WHERE date = \"$date\") a ON c.camper_id = a.camper_id AND i.chug_instance_id = a.chug_instance_id ";
+        // filter by block, edah, group, and only show "active" campers
+        $sql .= "WHERE i.block_id = g.active_block_id AND c.inactive = 0 AND c.edah_id = $edahId and ch.group_id = $groupId ";
+        // order result by bunk and then last name
+        $sql .= "ORDER BY bunk, name";
+        
+        // run SQL
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+
+        
+        $attTable = "";
+        $bunkText = "";
+        $multipleBunks = False;
+        while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+            // breakdown of $row:
+                // [0] - camper id          [1] - name 
+                // [2] - bunk               [3] - chug assignment
+                // [4] - department         [5] - chug rosh/leader
+                // [6] - present (1/0)
+
+            // each time through the loop, we will create an html table row to include in the larger table
+            // it will signal if campers are present/absent by row color
+            $tr = "<tr class=\"";
+            if(!$row[6]) { // if absent
+                $tr .= "table-danger absent";
+            }
+            else {
+                $tr .= "present";
+            }
+            $tr .= "\">";
+
+            // bunk
+            $tr .= "<td>$row[2]</td>";
+            // name
+            $tr .= "<td>$row[1]</td>";
+
+            // chug assignment -- if department, leader are not null, include a tooltip indicating that info
+            $tooltipText = "";
+            if($row[4] != NULL && $row[5] != NULL) {
+                $tooltipText = "<b>Department:</b> $row[4]<br><b>Chug Leader:</b> $row[5]";
+            }
+            else if($row[4] != NULL) {
+                $tooltipText = "<b>Department:</b> $row[4]";
+            }
+            else if($row[5] != NULL) {
+                $tooltipText = "Chug Leader:</b> $row[5]";
+            }
+            if($tooltipText != "") {
+                $tr .= "<td><span data-bs-toggle=\"tooltip\" data-bs-html=\"true\" title=\"$tooltipText\" " . 
+                    "style=\"border-bottom: 1px dashed #999;text-decoration: none; \">$row[3]</span></td>";
+            }
+            else {
+                $tr .= "<td>$row[3]</td>";
+            }
+
+            $tr .= "</tr>";
+
+            $attTable .= $tr;
+
+            // test to see if there are multiple bunks or just one
+            if($bunkText == "") {
+                $bunkText = $row[2];
+            }
+            if($row[2] != $bunkText) {
+                $multipleBunks = True;
+            } 
+        }
+
+        // if there is only one bunk for the edah, no need to include bunk info in table
+        if(!$multipleBunks) {
+            $attTable = str_replace("><td>$bunkText</td>", ">", $attTable);
+        }
+
+        // final section which will be returned showing the attendance for the edah
+        $attendanceSection = "<div class=\"card card-body bg-light mb-3 edah-attendance\">";
+        $attendanceSection .= "<h5 class=\"text-center\" id=\"edah$edahId\">Edah: " . $edahId2Name[$edahId] . "</h5>";
+        $attendanceSection .= "<table class=\"table table-striped table-hover\" id=\"attendance$edahId\"><thead class=\"table-dark\"><tr>";
+        if($multipleBunks) {
+            $attendanceSection .= "<th scope=\"col\">Bunk</th>";
+        }
+        $attendanceSection .= "<th scope=\"col\">Name</th><th scope=\"col\">Chug Assignment</th></tr></thead>";
+        $attendanceSection .= "<tbody>" . $attTable . "</tbody>";
+        $attendanceSection .= "</table>";
+        $attendanceSection .= "<button type=\"button\" class=\"btn btn-info mx-auto\" onclick=\"copyReport($edahId)\">Copy Missing Camper Report</button>";
+        $attendanceSection .= "</div>";
+        if($attTable != "") {
+            echo $attendanceSection;
+        }
+    }
+
+    ?>
+
+
+
+</div>
+
+<div class="toast-container position-fixed bottom-0 end-0">
+    <div class="toast m-3 align-items-center" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="toast-header">
+            Success! Missing camper report copied to clipboard
+        </div>
+    </div>
+</div>
+
+</body>
+
+<?php 
+function validate_form_inputs()
+{
+    $fullErrorMsg = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+        "Invalid Selections</h5>Return to <a href=\"chugLeaderHome.php\" class=\"alert-link\">previous page</a> to fix following issue(s):<ul class=\"mb-0\">";
+    $errors = "";
+
+    // declare scope of variables
+    global $edahIds, $rawEdahIds, $date, $groupId, $chugId;
+
+    // Step 1: edah ids
+    foreach($rawEdahIds as $i => $id) {
+        $id = trim($id);
+        $id = stripslashes($id);
+        $id = htmlspecialchars($id);
+        $rawEdahIds[$i] = $id;
+    }
+
+    // sort edahIds by proper sort_order
+    $localErr = "";
+    $dbc = new DbConn();
+    $sql = "SELECT edah_id FROM edot ORDER BY sort_order";
+    $result = $dbc->doQuery($sql, $localErr);
+    if ($result == false) {
+        echo dbErrorString($sql, $localErr);
+        exit();
+    }
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+        if(in_array($row[0], $rawEdahIds)) {
+            array_push($edahIds, $row[0]);
+        }
+    }
+    if(count($edahIds) == 0) {
+        $errors .= "<li>Improper edah id(s)</li>";
+    }
+
+
+    // Step 2: date format
+    $fullDate = strtotime($date);
+    $date = date('Y-m-d', $fullDate);
+    if($fullDate == "") {
+        $errors .= "<li>Invalid date</li>";
+    }
+    
+    // Step 3: group id valid
+    $localErr = "";
+    $dbc = new DbConn();
+    $sql = "SELECT g.group_id FROM chug_groups g WHERE g.group_id = " . intval($groupId) . " AND g.active_block_id IS NOT NULL";
+    $result = $dbc->doQuery($sql, $localErr);
+    if ($result == false) {
+        echo dbErrorString($sql, $localErr);
+        exit();
+    }
+    if($result->num_rows != 1) {
+        $errors .= "<li>Perek not properly selected</li>";
+    }
+
+    // build/return final error message if necessary
+    if($errors != "") {
+        echo $fullErrorMsg . $errors . "</ul></div></div>";
+        exit();
+    }
+}
+
+?>
+
+<script>
+    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+
+
+    function togglePresent() {
+        var toggle = document.getElementById("all_absent_switch");
+        var divsToHide = document.getElementsByClassName("present"); //divsToHide is an array
+        var visibility = ""; // default
+        if(toggle.checked) {
+            // only show absent campers, so hide present ones
+            visibility = "none";
+        }
+        for(var i = 0; i < divsToHide.length; i++){
+            divsToHide[i].style.display = visibility;
+        }
+    }
+
+    function copyReport(edahId) {
+        var output = "";
+        var table = document.getElementById("attendance"+edahId);
+        var absent = table.querySelectorAll(".absent");
+        output += document.getElementById("edah"+edahId).innerHTML + " Missing Campers\n";
+        output += "<?php echo $groupId2Name[$groupId]; ?> -- <?php echo $date; ?>";
+
+        // bunk not included
+        if (table.rows[0].cells.length === 2) {
+            absent.forEach((row) => {
+                var camperName = row.cells[0].innerHTML;
+                var camperChug = row.cells[1].innerHTML;
+                if(row.cells[1].hasChildNodes()) {
+                    // handle case where there is a tooltip -- unneeded info
+                    camperChug = row.cells[1].firstChild.innerHTML;
+                }
+                // add camper info
+                output += "\n * " + camperName + " (" + camperChug + ")";
+            });
+        }
+        // bunk included
+        else {
+            var bunk = "";
+            absent.forEach((row) => {
+                var camperBunk = row.cells[0].innerHTML;
+                var camperName = row.cells[1].innerHTML;
+                var camperChug = row.cells[2].innerHTML;
+                if(row.cells[2].hasChildNodes()) {
+                    // handle case where there is a tooltip -- unneeded info
+                    camperChug = row.cells[2].firstChild.innerHTML;
+                }
+                // check if this camper's bunk is same as previous; if not, start new section in report
+                if(bunk != camperBunk) {
+                    output += "\nBunk: " + camperBunk;
+                    bunk = camperBunk;
+                }
+                // add camper info
+                output += "\n * " + camperName + " (" + camperChug + ")";
+            });
+        }
+        navigator.clipboard.writeText(output);
+
+        /*var toastElList = [].slice.call(document.querySelectorAll('.toast'))
+        var toastList = toastElList.map(function(toastEl) {
+            return new bootstrap.Toast(toastEl)
+        })
+        console.log(toastList)
+        toastList.forEach(toast => toast.show()) */
+
+        $('.toast').toast({
+                    animation: false,
+                    delay: 3000
+                });
+                $('.toast').toast('show');
+    }
+</script>

--- a/chugbot/attendance/viewAttendance.php
+++ b/chugbot/attendance/viewAttendance.php
@@ -338,7 +338,7 @@ function validate_form_inputs()
                 var camperBunk = row.cells[1].innerText;
                 var camperName = row.cells[2].innerText;
                 var camperChug = row.cells[3].innerText;
-                if(row.cells[3].hasChildNodes()) {
+                if(row.cells[3].firstChild.hasChildNodes()) {
                     // handle case where there is a tooltip -- unneeded info
                     camperChug = row.cells[3].firstChild.innerText;
                 }

--- a/chugbot/attendance/viewAttendanceMatrix.php
+++ b/chugbot/attendance/viewAttendanceMatrix.php
@@ -1,0 +1,322 @@
+<?php
+    session_start();
+    include_once '../dbConn.php';
+    include_once '../functions.php';
+    bounceToLogin("rosh");
+    checkLogout();
+    setup_camp_specific_terminology_constants();
+
+    $dbErr = "";
+    $sessionId2Name = array();
+    $blockId2Name = array();
+    $groupId2Name = array();
+    $edahId2Name = array();
+    $chugId2Name = array();
+    $bunkId2Name = array();
+
+    fillId2Name(null, $chugId2Name, $dbErr, "chug_id", "chugim", "group_id", "chug_groups");
+    fillId2Name(null, $sessionId2Name, $dbErr, "session_id", "sessions");
+    fillId2Name(null, $blockId2Name, $dbErr, "block_id", "blocks");
+    fillId2Name(null, $groupId2Name, $dbErr, "group_id", "chug_groups");
+    fillId2Name(null, $edahId2Name, $dbErr, "edah_id", "edot");
+    fillId2Name(null, $bunkId2Name, $dbErr, "bunk_id", "bunks");
+
+    echo headerText("View Attendance Matrix");
+
+    // Get info from the form
+    $startDate = test_get_input('start-date');
+    $endDate = test_get_input('end-date');
+    $edahId = test_get_input('edah');
+
+    // additional function (at bottom of code) to ensure everything was properly formatted and valid values
+    // were passed in
+    validate_form_inputs();
+
+    // get group ids for the edah to be used in creating individual tables
+    $groupIds = array();
+    $localErr = "";
+    $dbc = new DbConn();
+    $sql = "SELECT group_id FROM edot_for_group WHERE edah_id = $edahId";
+    $result = $dbc->doQuery($sql, $localErr);
+    if ($result == false) {
+        echo dbErrorString($sql, $localErr);
+        exit();
+    }
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+        array_push($groupIds, $row[0]);
+    }
+    if(count($groupIds) == 0) {
+        echo "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+        "No Available Prakim</h5>No prakim are available for the provided edah. Contact an administrator if you believe this to be an error.</div></div>";
+        exit();
+    }
+
+
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+<div class="card card-body mt-2 p-3 mb-3 ms-5 me-5">
+    <h1>View Attendance Matrix</h1>
+    <div class="page-header"><h2><?php echo $edahId2Name[$edahId]; ?> Attendance Matrix</h2>
+    <h4> Dates: <?php echo date("D F j, Y", strtotime($startDate)) . " - " . date("D F j, Y", strtotime($endDate)); ?> </h4>
+    </div>
+
+    <p>Utilize this attendance matrix to explore trends within an edah by perek. There is a separate table for each perek below, and in each one, campers have their own row reflecting their attendance records.
+    Campers marked as absent on a particular day have the corresponding cell highlighted in <span style="background:#f8d7da;">red</span> and denoted with this icon: <i class="bi bi-x-circle-fill"></i>. 
+    Campers for whom attendance has not been taken have the cell for that day highlighted in <span style="background:#fff3cd;">yellow</span> and marked with this icon: <i class="bi bi-exclamation-triangle"></i>.
+    Otherwise, campers marked as present have no highlighting and are noted with this icon: <i class="bi bi-check-circle"></i>.
+    Hover over the corresponding icon for a camper on a particular day to see their attendance status and which <?php echo chug_term_singular; ?> they were assigned for that day.</p>
+
+
+    <?php
+    $tableCount = 0;
+    foreach($groupIds as $groupId) {
+        // step 1: SQL to get dates and correct block for that date
+        $date2BlockId = array();
+        $localErr = "";
+        $dbc = new DbConn();
+        $sql = "SELECT date, block_id FROM attendance_block_by_date WHERE group_id = $groupId AND date >= '$startDate' AND date <= '$endDate' ORDER BY date";
+        $result = $dbc->doQuery($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+        while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+            array_push($date2BlockId, array($row[0], $row[1])); // [date, block_id]
+        }
+        if(count($date2BlockId) == 0) {
+            continue;
+        }
+
+
+        // step 2: build mega SQL to get camper, present/absent by date (also creates the heading for dates)
+        $localErr = "";
+        $db = new DbConn();
+        // basic info
+        $initialSql = "SELECT c.camper_id, b.name as bunk, CONCAT(c.last, ', ', c.first) AS name, ";
+        foreach($date2BlockId as $dateBlockArr) {
+            // attendance status for date
+            $initialSql .= "MAX(CASE WHEN a.date = '$dateBlockArr[0]' THEN a.present ELSE NULL END) AS \"$dateBlockArr[0]\",";
+            // chug assignment for date
+            $initialSql .= "COALESCE(MAX(CASE WHEN m.camper_id = c.camper_id AND ci.block_id = $dateBlockArr[1] THEN ch.name END),'No assignment') " .
+                "AS \"$dateBlockArr[0]-chug\",";
+        }
+        // trim final comma - okay because already ensured there are 1+ dates
+        $initialSql = rtrim($initialSql, ",") . " ";
+        // add FROM/JOINS to SQL
+        $initialSql .= "FROM campers c " .
+            "JOIN block_instances bi ON c.session_id = bi.session_id " . 
+            "JOIN attendance a ON a.camper_id = c.camper_id " . 
+            "JOIN matches m ON m.camper_id = c.camper_id " . 
+            "JOIN chug_instances ci ON ci.chug_instance_id = m.chug_instance_id " . 
+            "JOIN chugim ch ON ch.chug_id = ci.chug_id " . 
+            "JOIN bunks b on b.bunk_id = c.bunk_id ";
+        // only this edah and group_id
+        $initialSql .= "WHERE ch.group_id = $groupId AND c.edah_id = $edahId ";
+        // grouping, ordering
+        $initialSql .= "GROUP BY c.camper_id ORDER BY bunk, name";
+
+        // determine if entire column is null
+        $secondSql = "SELECT initial_result.`camper_id`, initial_result.`bunk`, initial_result.`name`,";
+        // previous 2 columns + null check, by date
+        foreach($date2BlockId as $dateBlockArr) {
+            // 2 columns from initial result
+            $secondSql .= " initial_result.`$dateBlockArr[0]`, initial_result.`$dateBlockArr[0]-chug`, ";
+            // null check based on those columns
+            $secondSql .= "CASE WHEN COUNT(`$dateBlockArr[0]`) OVER () = 0 THEN 1 ELSE 0 END AS `$dateBlockArr[0]_all_null`,";
+        }
+        // trim final comma - okay because already ensured there are 1+ dates
+        $secondSql = rtrim($secondSql, ",") . " ";
+        // conclude second part
+        $secondSql .= "FROM initial_result";
+
+        // build SQL from pieces
+        $sql = "WITH initial_result AS ($initialSql) $secondSql";
+
+
+        // run SQL
+        $result = $db->runQueryDirectly($sql, $localErr);
+        if ($result == false) {
+            echo dbErrorString($sql, $localErr);
+            exit();
+        }
+
+        // step 3: build table
+        $attTable = "";
+        $bunkText = "";
+        $multipleBunks = False;
+        $dateColHeadings = "";
+        $rowsMade = 0;
+        while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+            //print_r($row);
+            //echo "<br>";
+            // breakdown of $row:
+                // [0] - camper id                  [1] - bunk 
+                // [2] - name                       [3, 6, 9, ...] - attendance status
+                // [4, 7, 10, ...] - chug assigned corresponding to previous status
+                // [5, 8, 11, ...] - 1 if no attendance was taken this day; 0 otherwise
+
+            // each time through the loop, we will create an html table row to include in the larger table
+            // it will signal if campers are present/absent by cell color
+            $tr = "<tr>";
+
+            // bunk
+            $tr .= "<td>$row[1]</td>";
+            // name
+            $tr .= "<td>$row[2]</td>";
+
+            // rest of row will be composed of status icons corresponding to present/absent/attendance not taken, and hovering
+            // on that icon will say status and chug assignment (if exists)
+            for($i = 3; $i < count($row); $i += 3) {
+                if($row[$i+2] != 1) {
+                    // determine unique data for this camper and day
+                    $tooltipText = $icon = $class = "";
+                    if(is_null($row[$i])) { // attendance not yet taken
+                        $tooltipText = "<b>Attendance Not Taken</b><br><b>" . ucfirst(chug_term_singular) . ":</b>${row[$i+1]}";
+                        $icon = "<i class=\"bi bi-exclamation-triangle\"></i>";
+                        $class = "table-warning";
+                    }
+                    else if($row[$i] == 0) { // absent
+                        $tooltipText = "<b>Absent</b><br><b>" . ucfirst(chug_term_singular) . ":</b>${row[$i+1]}";
+                        $icon = "<i class=\"bi bi-x-circle-fill\"></i>";
+                        $class = "table-danger";
+                    }
+                    else if ($row[$i] == 1) { // present
+                        $tooltipText = "<b>Present</b><br><b>" . ucfirst(chug_term_singular) . ":</b>${row[$i+1]}";
+                        $icon = "<i class=\"bi bi-check-circle\"></i>";
+                    }
+
+                    // assemble cell
+                    $tr .= "<td class=\"text-center align-middle $class\"><span data-bs-toggle=\"tooltip\" data-bs-html=\"true\" title=\"$tooltipText\" " . 
+                        "style=\"border-bottom: 1px dashed #999;text-decoration: none;\">$icon</span></td>";
+                }
+            }
+
+            $tr .= "</tr>";
+
+            $attTable .= $tr;
+
+            // test to see if there are multiple bunks or just one
+            if($bunkText == "") {
+                $bunkText = $row[1];
+            }
+            if($row[1] != $bunkText) {
+                $multipleBunks = True;
+            } 
+
+            // if this is the first iteration, make correct column headers
+            if ($rowsMade == 0) {
+                $fieldInfo = $result->fetch_fields();
+                for($i = 3; $i < count($row); $i += 3) {
+                    if($row[$i+2] != 1) {
+                        $fieldinfo = mysqli_fetch_field_direct($result, $i);
+                        $dateColHeadings .= "<th scope=\"col\">" . date("D F j, Y", strtotime($fieldInfo[$i]->name)) . "</th>";
+                    }
+                }
+            }
+            $rowsMade++;
+        }
+
+        // if there is only one bunk for the edah, no need to include bunk info in table
+        if(!$multipleBunks) {
+            $attTable = str_replace("><td>$bunkText</td>", ">", $attTable);
+        }
+
+        // final section which will be returned showing the attendance matrix for the edah
+        if($dateColHeadings != "" && $rowsMade > 0) {
+            $attendanceMatrix = "<div class=\"card card-body bg-light mb-3 mt-3 attendance-matrix\">";
+            $attendanceMatrix .= "<h5 class=\"text-center\" id=\"group$groupId\">" . $edahId2Name[$edahId] . ": <b>" . $groupId2Name[$groupId] . "</b></h5>";
+            $attendanceMatrix .= "<table class=\"table table-hover\" id=\"attendanceMatrix$groupId\"><thead class=\"table-dark\"><tr>";
+            if($multipleBunks) {
+                $attendanceMatrix .= "<th scope=\"col\">Bunk</th>";
+            }
+            $attendanceMatrix .= "<th scope=\"col\">Name</th>$dateColHeadings</tr></thead>";
+            $attendanceMatrix .= "<tbody>" . $attTable . "</tbody>";
+            $attendanceMatrix .= "</table>";
+            $attendanceMatrix .= "</div>";
+            if($attTable != "") {
+                echo $attendanceMatrix;
+            }
+            $tableCount++;
+        }
+    }
+
+    // if no tables were made (all null, no attendance taken, bad dates, etc) display message indicating that
+    if($tableCount == 0) {
+        echo "<div class=\"alert alert-info mt-4 col-lg-8 offset-sm-2\" role=\"alert\"><h5>No Attendance Taken for Selected Dates</h5>" . 
+        "No attendance records were found for $edahId2Name[$edahId] for the selected dates, so no summary matrix can be shown.</div>";
+    }
+    ?>
+
+
+</div>
+</body>
+<script>
+    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+</script>
+
+
+<?php 
+function validate_form_inputs()
+{
+    $fullErrorMsg = "<div class=\"col-md-6 offset-md-3\"><div class=\"alert alert-danger alert-dismissible fade show m-2\" role=\"alert\">" . 
+        "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button><h5><strong>Error:</strong> " . 
+        "Invalid Selections</h5>Return to <a href=\"roshHome.php\" class=\"alert-link\">previous page</a> to fix following issue(s):<ul class=\"mb-0\">";
+    $errors = "";
+
+    // declare scope of variables
+    global $edahId, $startDate, $endDate;
+
+    // Step 1: edah id
+    // get all edah ids, and then ensure there is a match between passed one and list
+    $valid = false;
+    $localErr = "";
+    $dbc = new DbConn();
+    $sql = "SELECT edah_id FROM edot";
+    $result = $dbc->doQuery($sql, $localErr);
+    if ($result == false) {
+        echo dbErrorString($sql, $localErr);
+        exit();
+    }
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
+        if($edahId == $row[0]) {
+            $valid = true;
+            break;
+        }
+    }
+    if(!$valid) {
+        $errors .= "<li>Improper edah id</li>";
+    }
+
+    // Step 2: start, end date format
+    $fullDate = strtotime($startDate);
+    $startDate = date('Y-m-d', $fullDate);
+    if($fullDate == "") {
+        $errors .= "<li>Invalid start date</li>";
+    }
+
+    // Step 3: start, end date format
+    $fullDate = strtotime($endDate);
+    $endDate = date('Y-m-d', $fullDate);
+    if($fullDate == "") {
+        $errors .= "<li>Invalid end date</li>";
+    }
+
+    // Step 4: verify start date is before end date
+    if(strtotime($endDate) < strtotime($startDate)) {
+        $errors .= "<li>End date is before start date -- order must be reversed</li>";
+    }
+    
+
+    // build/return final error message if necessary
+    if($errors != "") {
+        echo $fullErrorMsg . $errors . "</ul></div></div>";
+        exit();
+    }
+}
+
+?>

--- a/chugbot/attendance/viewAttendanceMatrix.php
+++ b/chugbot/attendance/viewAttendanceMatrix.php
@@ -97,7 +97,7 @@
         $initialSql = "SELECT c.camper_id, b.name as bunk, CONCAT(c.last, ', ', c.first) AS name, ";
         foreach($date2BlockId as $dateBlockArr) {
             // attendance status for date
-            $initialSql .= "MAX(CASE WHEN a.date = '$dateBlockArr[0]' THEN a.present ELSE NULL END) AS \"$dateBlockArr[0]\",";
+            $initialSql .= "MAX(CASE WHEN a.date = '$dateBlockArr[0]' AND a.camper_id = c.camper_id THEN a.present ELSE NULL END) AS \"$dateBlockArr[0]\",";
             // chug assignment for date
             $initialSql .= "COALESCE(MAX(CASE WHEN m.camper_id = c.camper_id AND ci.block_id = $dateBlockArr[1] THEN ch.name END),'No assignment') " .
                 "AS \"$dateBlockArr[0]-chug\",";
@@ -107,9 +107,9 @@
         // add FROM/JOINS to SQL
         $initialSql .= "FROM campers c " .
             "JOIN block_instances bi ON c.session_id = bi.session_id " . 
-            "JOIN attendance a ON a.camper_id = c.camper_id " . 
             "JOIN matches m ON m.camper_id = c.camper_id " . 
             "JOIN chug_instances ci ON ci.chug_instance_id = m.chug_instance_id " . 
+            "JOIN attendance a ON a.camper_id = c.camper_id AND a.chug_instance_id = ci.chug_instance_id " . 
             "JOIN chugim ch ON ch.chug_id = ci.chug_id " . 
             "JOIN bunks b on b.bunk_id = c.bunk_id ";
         // only this edah and group_id
@@ -149,8 +149,6 @@
         $dateColHeadings = "";
         $rowsMade = 0;
         while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
-            //print_r($row);
-            //echo "<br>";
             // breakdown of $row:
                 // [0] - camper id                  [1] - bunk 
                 // [2] - name                       [3, 6, 9, ...] - attendance status

--- a/chugbot/camperHome.php
+++ b/chugbot/camperHome.php
@@ -3,6 +3,7 @@ include_once 'dbConn.php';
 include_once 'functions.php';
 include_once 'formItem.php';
 session_start();
+checkLogout();
 
 setup_camp_specific_terminology_constants();
 

--- a/chugbot/camperUpload.php
+++ b/chugbot/camperUpload.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'dbConn.php';
 include_once 'functions.php';
 bounceToLogin();
+checkLogout();
 
 // Check for a query string that signals a message.
 $parts = explode("&", $_SERVER['QUERY_STRING']);

--- a/chugbot/dbConn.php
+++ b/chugbot/dbConn.php
@@ -253,6 +253,10 @@ function fillId2Name($archiveYear,
         $db->addSelectColumn($secondIdColumn);
     }
     $db->addSelectColumn("name");
+    if ($table == "edot") {
+        $db->addSelectColumn("sort_order");
+        $db->addOrderByClause(" ORDER BY sort_order");
+    }
     $result = $db->simpleSelectFromTable($table, $dbErr);
     if ($result == false) {
         error_log($dbErr);

--- a/chugbot/delete.php
+++ b/chugbot/delete.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'functions.php';
 include_once 'dbConn.php';
 bounceToLogin();
+checkLogout();
 
 $dbErr = $itemIdErr = $qsErr = "";
 $comma_sep = $table_name = $item_id = $id_col = "";

--- a/chugbot/designSchedules.php
+++ b/chugbot/designSchedules.php
@@ -3,6 +3,7 @@
     include_once 'dbConn.php';
     include_once 'functions.php';
     bounceToLogin();
+    checkLogout();
     setup_camp_specific_terminology_constants();
 
     $dbErr = "";

--- a/chugbot/designSchedules.php
+++ b/chugbot/designSchedules.php
@@ -2,7 +2,7 @@
     session_start();
     include_once 'dbConn.php';
     include_once 'functions.php';
-    bounceToLogin();
+    bounceToLogin("rosh");
     checkLogout();
     setup_camp_specific_terminology_constants();
 
@@ -249,7 +249,7 @@
 <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
 <div class="modal-dialog modal-lg">
 <div class="modal-content">
-    <div class="modal-header">
+    <div class="modal-header bg-warning">
         <h5 class="modal-title" id="deleteModalLabel">Delete Schedule Template</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
     </div>

--- a/chugbot/editBlock.php
+++ b/chugbot/editBlock.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $block_term_singular = block_term_singular;

--- a/chugbot/editBunk.php
+++ b/chugbot/editBunk.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $editBunkPage = new EditPage("Edit Bunk",
     "Please edit information for this bunk",

--- a/chugbot/editCamper.php
+++ b/chugbot/editCamper.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 camperBounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $db = new DbConn();

--- a/chugbot/editChug.php
+++ b/chugbot/editChug.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $editChugPage = new EditPage("Edit " . ucfirst(chug_term_singular),

--- a/chugbot/editEdah.php
+++ b/chugbot/editEdah.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $editEdahPage = new EditPage("Edit Edah",
     "Please update edah information as needed",

--- a/chugbot/editGroup.php
+++ b/chugbot/editGroup.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $editGroupPage = new EditPage("Edit Group", "Please update group information as needed",
     "chug_groups", "group_id");

--- a/chugbot/editSession.php
+++ b/chugbot/editSession.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'addEdit.php';
 include_once 'formItem.php';
 bounceToLogin();
+checkLogout();
 
 $editSessionPage = new EditPage("Edit Session", "Please update session information as needed",
     "sessions", "session_id");

--- a/chugbot/formItem.php
+++ b/chugbot/formItem.php
@@ -165,7 +165,11 @@ class FormItemSingleTextField extends FormItem
         $this->html .= "<div>\n";
         $this->html .= "<input id=\"$this->inputName\" name=\"$this->inputName\" placeholder=\"$ph\" " .
             "class=\"form-control $this->inputClass\" type=\"$this->inputType\" $this->inputMaxLengthHtml " .
-            "value=\"$this->inputValue\"/>\n";
+            "value=\"$this->inputValue\"";
+        if($this->required) {
+            $this->html .= " required";
+        }
+        $this->html .= "/>\n";
         if ($this->error) {
             $this->html .= "<span class=\"error\">$this->error</span>\n";
         }

--- a/chugbot/functions.php
+++ b/chugbot/functions.php
@@ -923,7 +923,6 @@ function navText()
     }
     if (roshLoggedIn()) {
         $roshUrl = urlIfy("../attendance/roshHome.php");
-        //$retVal .= "<li class=\"nav-item\"><a class=\"nav-link\" href=\"$roshUrl\">Rosh/Yoetzet Home</a></li>";
         $retVal .= "<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" id=\"roshNavbarDropdown\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">" . 
             "Rosh/Yoetzet</a><ul class=\"dropdown-menu\" aria-labelledby=\"roshNavbarDropdown\">" .
             "<li><a class=\"dropdown-item\" href=\"$roshUrl\">Rosh/Yoetzet Home (Attendance Module)</a></li>" . 

--- a/chugbot/functions.php
+++ b/chugbot/functions.php
@@ -456,6 +456,8 @@ JS;
 // NOTE: fillConstraintsPickList() must be called as an `onchange` method
 //     from the element which it relies upon
 function genConstrainedPickListScript($ourId, $parentId, $descId, $type, $choicesJS = false) {
+    // Ensure $choicesJS is converted to a JavaScript boolean value
+    $choicesJS = $choicesJS ? 'true' : 'false';
     $javascript = <<<JS
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
@@ -467,7 +469,7 @@ function fillConstraintsPickList() {
     var values = {};
     values["get_legal_id_to_name"] = 1;
     $(ourDesc).hide();
-    if(!$("#${choicesJS}")) {
+    if(!${choicesJS}) {
         var parentField = document.getElementsByName("${parentId}")[0];
     }
     else {
@@ -552,7 +554,7 @@ function fillConstraintsPickList() {
         $(ourPickList).append(html);
         $(ourPickList).show();
         $(ourDesc).show();
-        if($("#${choicesJS}")) {
+        if(${choicesJS}) {
             const choices = new Choices($(ourPickList).find('select')[0], {shouldSort: false, allowHTML: true, searchEnabled: false});
         }
         },
@@ -921,7 +923,12 @@ function navText()
     }
     if (roshLoggedIn()) {
         $roshUrl = urlIfy("../attendance/roshHome.php");
-        $retVal .= "<li class=\"nav-item\"><a class=\"nav-link\" href=\"$roshUrl\">Rosh/Yoetzet Home</a></li>";
+        //$retVal .= "<li class=\"nav-item\"><a class=\"nav-link\" href=\"$roshUrl\">Rosh/Yoetzet Home</a></li>";
+        $retVal .= "<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" id=\"roshNavbarDropdown\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">" . 
+            "Rosh/Yoetzet</a><ul class=\"dropdown-menu\" aria-labelledby=\"roshNavbarDropdown\">" .
+            "<li><a class=\"dropdown-item\" href=\"$roshUrl\">Rosh/Yoetzet Home (Attendance Module)</a></li>" . 
+            "<li><a class=\"dropdown-item\" href=\"../designSchedules.php\">Schedule Builder</a></li>" . 
+            "</ul></li>";
     }
     if (chugLeaderLoggedIn()) {
         $chugLeaderUrl = urlIfy("../attendance/chugLeaderHome.php");

--- a/chugbot/functions.php
+++ b/chugbot/functions.php
@@ -344,7 +344,9 @@ function genPickList($id2Name, $selectedMap, $name, $defaultMessage = null)
         $ddMsg = $defaultMessage;
     }
     $retVal = "<option value=\"\" >-- $ddMsg --</option>";
-    asort($id2Name);
+    if($name != "edah" && !strstr($name, "edot_for")) {
+        asort($id2Name);
+    }
     foreach ($id2Name as $id => $name) {
         $selStr = "";
         if (array_key_exists($id, $selectedMap)) {
@@ -358,7 +360,9 @@ function genPickList($id2Name, $selectedMap, $name, $defaultMessage = null)
 function genCheckBox($id2Name, $activeIds, $arrayName)
 {
     $retVal = "";
-    asort($id2Name);
+    if($arrayName != "edah_ids" && !strstr($arrayName, "edot_for")) {
+        asort($id2Name);
+    }
     foreach ($id2Name as $id => $name) {
         $selStr = "";
         $idStr = strval($id); // Use strings in forms, for consistency.
@@ -400,6 +404,9 @@ function fillConstraintsCheckBox() {
         sql += "?";
     }
     sql += ") AND e.group_id = g.group_id GROUP BY e.group_id HAVING COUNT(e.edah_id) = " + ct;
+    if(ourCheckBox === "edah") {
+        sql += " SORT BY e.sort_order";
+    }
     values["sql"] = sql;
     values["instance_ids"] = curSelectedEdahIds;
     $.ajax({
@@ -483,6 +490,9 @@ function fillConstraintsPickList() {
             sql += "?";
         }
         sql += ") AND e.${type}_id = g.${type}_id GROUP BY e.${type}_id HAVING COUNT(e.edah_id) = " + ct;
+    }
+    if(ourPickList === "edah") {
+        sql += " SORT BY e.sort_order";
     }
     values["sql"] = sql;
     values["instance_ids"] = curSelectedEdahIds;
@@ -745,9 +755,9 @@ function headerText($title)
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>$title</title>
-<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-<script type="text/javascript" src="meta/view.js"></script>
-<link rel="stylesheet" type="text/css" href="meta/view.css" media="all">
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
+<script type="text/javascript" src="../meta/view.js"></script>
+<link rel="stylesheet" type="text/css" href="../meta/view.css" media="all">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>

--- a/chugbot/functions.php
+++ b/chugbot/functions.php
@@ -901,6 +901,7 @@ function checkLogout()
 
 function navText()
 {
+    setup_camp_specific_terminology_constants();
     $homeUrl = homeUrl();
     $retVal = "<nav class=\"navbar navbar-expand-lg navbar-light bg-light\">";
     $baseUrl = baseUrl();
@@ -911,7 +912,12 @@ function navText()
     $retVal .= "<div class=\"collapse navbar-collapse\" id=\"navbarSupportedContent\">";
     $retVal .= "<ul class=\"navbar-nav me-auto mb-2 mb-lg-0\">";
     if (adminLoggedIn()) {
-        $retVal .= "<li class=\"nav-item\"><a class=\"nav-link\" href=\"$homeUrl\">Admin Home</a></li>";
+        $adminAttendanceUrl = urlIfy("../attendance/");
+        $retVal .= "<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" id=\"adminNavbarDropdown\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">" . 
+            "Admin</a><ul class=\"dropdown-menu\" aria-labelledby=\"adminNavbarDropdown\">" .
+            "<li><a class=\"dropdown-item\" href=\"$homeUrl\">Main Admin Home</a></li>" . 
+            "<li><a class=\"dropdown-item\" href=\"$adminAttendanceUrl\">Admin Attendance Settings</a></li>" . 
+            "</ul></li>";
     }
     if (roshLoggedIn()) {
         $roshUrl = urlIfy("../attendance/roshHome.php");
@@ -919,7 +925,7 @@ function navText()
     }
     if (chugLeaderLoggedIn()) {
         $chugLeaderUrl = urlIfy("../attendance/chugLeaderHome.php");
-        $retVal .= "<li class=\"nav-item\"><a class=\"nav-link\" href=\"$chugLeaderUrl\">Chug Leader Home</a></li>";
+        $retVal .= "<li class=\"nav-item\"><a class=\"nav-link\" href=\"$chugLeaderUrl\">" . ucfirst(chug_term_singular) . " Leader Home</a></li>";
     }
     if (camperLoggedIn()) {
         $camperUrl = urlIfy("../camperHome.php");

--- a/chugbot/functions.php
+++ b/chugbot/functions.php
@@ -896,7 +896,7 @@ function headerText($title)
 <link rel="stylesheet" type="text/css" href="../meta/view.css" media="all">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
 <!--<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@4.5.2/dist/flatly/bootstrap.min.css" integrity="sha384-qF/QmIAj5ZaYFAeQcrQ6bfVMAh4zZlrGwTPY7T/M+iTTLJqJBJjwwnsE5Y0mV7QK" crossorigin="anonymous">-->
 </head>

--- a/chugbot/index.php
+++ b/chugbot/index.php
@@ -3,6 +3,7 @@ include_once 'dbConn.php';
 include_once 'functions.php';
 include_once 'formItem.php';
 session_start();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $loggedIn = (adminLoggedIn() || camperLoggedIn());
@@ -80,7 +81,7 @@ if (!$loggedIn) {
 </form>
 
 <form id="staffForm" class="form-group" method="post">
-<button class = "btn btn-light btn-outline-secondary mt-3" type="submit" name="staffInit" form="staffForm" formaction="staffLogin.php" value="1">Admin</button>
+<button class = "btn btn-light btn-outline-secondary mt-3" type="submit" name="staffInit" form="staffForm" formaction="staffLogin.php" value="1">Staff</button>
 </form>
 </div>
 

--- a/chugbot/levelHomeLaunch.php
+++ b/chugbot/levelHomeLaunch.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'assignment.php';
 include_once 'dbConn.php';
 bounceToLogin();
+checkLogout();
 $err = $dbErr = "";
 
 if ($_SERVER["REQUEST_METHOD"] != "GET") {

--- a/chugbot/matrix.php
+++ b/chugbot/matrix.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'functions.php';
 include_once 'dbConn.php';
 setup_camp_specific_terminology_constants();
+checkLogout();
 
 // Require admin-level access to use any functions.
 if (!adminLoggedIn()) {

--- a/chugbot/meta/view.css
+++ b/chugbot/meta/view.css
@@ -214,9 +214,9 @@ form li:after
 
 form li div
 {
-    color:#444;
+    /*color:#444;
     margin:0 4px 0 0;
-    padding:0 0 8px;
+    padding:0 0 8px;*/
 }
 
 form li span

--- a/chugbot/meta/view.css
+++ b/chugbot/meta/view.css
@@ -150,7 +150,6 @@ img
     border:1px solid #333;
     background-color:#161616;
     border-radius:5px;
-    padding:10px;
     color:#fff;
     font-size:12px Arial;
 }

--- a/chugbot/preEditCamper.php
+++ b/chugbot/preEditCamper.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'dbConn.php';
 include_once 'functions.php';
 setup_camp_specific_terminology_constants();
+checkLogout();
 
 $db = new DbConn();
 $sql = "SELECT enable_selection_process FROM admin_data";

--- a/chugbot/printSchedules.php
+++ b/chugbot/printSchedules.php
@@ -3,6 +3,7 @@
     include_once 'dbConn.php';
     include_once 'functions.php';
     bounceToLogin();
+    checkLogout();
     setup_camp_specific_terminology_constants();
     echo headerText("Print Schedules");
 

--- a/chugbot/printSchedules.php
+++ b/chugbot/printSchedules.php
@@ -2,7 +2,7 @@
     session_start();
     include_once 'dbConn.php';
     include_once 'functions.php';
-    bounceToLogin();
+    bounceToLogin("rosh");
     checkLogout();
     setup_camp_specific_terminology_constants();
     echo headerText("Print Schedules");

--- a/chugbot/report.php
+++ b/chugbot/report.php
@@ -5,6 +5,7 @@ include_once 'functions.php';
 include_once 'formItem.php';
 require_once 'fpdf/fpdf.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 abstract class OutputTypes

--- a/chugbot/staffHome.php
+++ b/chugbot/staffHome.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'dbConn.php';
 include_once 'functions.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 // Check for a query string that signals a message.

--- a/chugbot/staffLogin.php
+++ b/chugbot/staffLogin.php
@@ -5,7 +5,10 @@ include_once 'formItem.php';
 include_once 'dbConn.php';
 
 // If the user is already logged in, redirect.
-bouncePastIfLoggedIn("staffHome.php");
+bouncePastIfLoggedIn("staffHome.php", "admin");
+bouncePastIfLoggedIn("attendance/roshHome.php", "rosh");
+bouncePastIfLoggedIn("attendance/chugLeaderHome.php", "chugLeader");
+
 
 // Check to see if there is an existing admin password.  If so, we'll
 // prompt the user for a password.  Otherwise, we will ask them to create
@@ -14,10 +17,10 @@ bouncePastIfLoggedIn("staffHome.php");
 // into this page.
 $forgotUrl = urlIfy("forgotPassword.php");
 $dbError = $staffPasswordErr = $staffPasswordErr2 = "";
-$existingPasswordHashed = "";
+$existingAdminPasswordHashed = $existingChugLeaderPasswordHashed = $existingRoshPasswordHashed = "";
 $staffPasswordHashed = "";
 $db = new DbConn();
-$sql = "SELECT admin_password from admin_data";
+$sql = "SELECT admin_password, chug_leader_password, rosh_yoetzet_password from admin_data";
 $result = $db->runQueryDirectly($sql, $dbError);
 if ($result == false) {
     $dbError = dbErrorString($sql, "Failed to query database: $dbError");
@@ -25,7 +28,9 @@ if ($result == false) {
     $dbError = dbErrorString($sql, "Bad row count for admin email and password");
 } else if ($result->num_rows == 1) {
     $row = mysqli_fetch_row($result);
-    $existingPasswordHashed = $row[0];
+    $existingAdminPasswordHashed = $row[0];
+    $existingChugLeaderPasswordHashed = $row[1];
+    $existingRoshPasswordHashed = $row[2];
 }
 
 $staffEmailErr = $staffPasswordErr = $staffPasswordErr2 = "";
@@ -33,7 +38,7 @@ $staffEmailErr = $staffPasswordErr = $staffPasswordErr2 = "";
 // Note the redirect text and destination.  The default is the staff home page,
 // but if there is a "from" query string, we redirect back to that page.
 $redirUrl = staffBounceBackUrl();
-$redirText = "directed to the camp staff home page.";
+$redirText = "directed to your camp staff home page.";
 if (fromBounce()) {
     $redirText = "redirected.";
 }
@@ -42,13 +47,14 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $staff_email = test_post_input("staff_email");
     $staff_password = test_post_input("staff_password");
     $staff_password2 = test_post_input("staff_password2");
+    $role = test_post_input("role");
 
     if (empty(test_post_input("staffInit"))) {
         // If we have POST data, we validate it, and update as needed.
         if (empty($staff_password)) {
             $staffPasswordErr = errorString("Please enter a staff password");
         }
-        if (empty($existingPasswordHashed)) {
+        if (empty($existingAdminPasswordHashed)) {
             // If we don't have an existing password, then we want to insert
             // the incoming data, provided there are no errors.
             if (strlen($staff_password) < 5 ||
@@ -75,7 +81,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 $dbConn = new DbConn();
                 $dbConn->addColumn("admin_email", $staff_email, 's');
                 $dbConn->addColumn("admin_password", $staffPasswordHashed, 's');
-                if (empty($existingPasswordHashed)) {
+                if (empty($existingAdminPasswordHashed)) {
                     $insertedOk = $dbConn->insertIntoTable("admin_data", $dbError);
                 } else {
                     $insertedOk = $dbConn->updateTable("admin_data", $dbError);
@@ -89,21 +95,58 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                     exit();
                 }
             }
-        } else if (empty($staffPasswordErr)) {
+        } else if (empty($staffPasswordErr) && !empty($role)) {
             // If we have an existing password, we just need to hash it
             // and match it against the database version, which is already hashed.
             // If they match, we set $_SESSION['admin_logged_in'] = TRUE;, and redirect
             // to the admin home page.
-            if (!password_verify($staff_password, $existingPasswordHashed)) {
-                $staffPasswordErr = errorString("Password does not match - please try again.") .
-                    "<p>If you forgot the password, please click <a href=\"$forgotUrl\">here</a>.</p>";
-                usleep(250000); // Sleep for 0.25 sec, to slow a dictionary attack.
-            } else {
-                // New password entered OK: redirect.
-                $_SESSION['admin_logged_in'] = true;
-                $_SESSION['camper_logged_in'] = true;
-                header("Location: $redirUrl");
-                exit();
+            if($role == "admin") {
+                if (!password_verify($staff_password, $existingAdminPasswordHashed)) {
+                    $staffPasswordErr = errorString("Password does not match - please try again.") .
+                        "<p>If you forgot the password, please click <a href=\"$forgotUrl\">here</a>.</p>";
+                    usleep(250000); // Sleep for 0.25 sec, to slow a dictionary attack.
+                } else {
+                    // New password entered OK: redirect.
+                    $_SESSION['admin_logged_in'] = true;
+                    $_SESSION['rosh_logged_in'] = true;
+                    $_SESSION['chug_leader_logged_in'] = true;
+                    $_SESSION['camper_logged_in'] = true;
+                    header("Location: $redirUrl");
+                    exit();
+                }
+            }
+            else if ($role == "chugleader") {
+                if (!password_verify($staff_password, $existingChugLeaderPasswordHashed)) {
+                    $staffPasswordErr = errorString("Password does not match - please try again.") .
+                        "<p>If you forgot the password, please click <a href=\"$forgotUrl\">here</a>.</p>";
+                    usleep(250000); // Sleep for 0.25 sec, to slow a dictionary attack.
+                } else {
+                    // New password entered OK: redirect.
+                    $_SESSION['chug_leader_logged_in'] = true;
+                    $_SESSION['camper_logged_in'] = true;
+                    if(!fromBounce()) {
+                        $redirUrl = "../attendance/chugLeaderHome.php";
+                    }
+                    header("Location: $redirUrl");
+                    exit();
+                }
+            }
+            else if ($role == "rosh") {
+                if (!password_verify($staff_password, $existingRoshPasswordHashed)) {
+                    $staffPasswordErr = errorString("Password does not match - please try again.") .
+                        "<p>If you forgot the password, please click <a href=\"$forgotUrl\">here</a>.</p>";
+                    usleep(250000); // Sleep for 0.25 sec, to slow a dictionary attack.
+                } else {
+                    // New password entered OK: redirect.
+                    $_SESSION['rosh_logged_in'] = true;
+                    $_SESSION['chug_leader_logged_in'] = true;
+                    $_SESSION['camper_logged_in'] = true;
+                    if(!fromBounce()) {
+                        $redirUrl = "../attendance/roshHome.php";
+                    }
+                    header("Location: $redirUrl");
+                    exit();
+                }
             }
         }
     }
@@ -126,23 +169,48 @@ if (!is_null($errText)) {
 <h1><a>Staff Login</a></h1>
 <form id="loginForm" method="post" action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]); ?>">
 <div class="page-header">
-<h2>Admin Staff Login</h2>
+<h2>Staff Login</h2>
 <?php
-if (empty($existingPasswordHashed)) {
+if (empty($existingAdminPasswordHashed)) {
     echo ("<p>Please create a staff password, and enter an email in case you need to reset or change the password.<br>");
     echo ("The password should be between 5 and 20 characters.</p>");
-} else {
-    echo ("<p>Please enter the staff admin password.  If you forgot the password, please click <a href=\"$forgotUrl\">here</a>.</p>");
 }
 echo loginRequiredMessage();
 echo "After logging in, you will be $redirText";
 ?>
 </div>
+<br>
 <ul>
-
 <?php
 $liNum = 0;
-if (empty($existingPasswordHashed)) {
+
+// if admin + other password(s) are set, show buttons to select correct one
+if(!empty($existingAdminPasswordHashed)) {
+    $roleSelectField = "<li id=\"li_0\">" . 
+        "<label class=\"description\" for=\"role\"><font color=\"red\">*</font>Select User Role</label>" .
+        "<div class=\"btn-group mb-2\" role=\"group\" aria-label=\"Basic example\">" . 
+        "<input type=\"radio\" class=\"btn-check\" name=\"role\" id=\"admin\" autocomplete=\"off\" value=\"admin\" required>" . 
+        "<label class=\"btn btn-outline-primary\" for=\"admin\">Admin</label>";
+    if(!empty($existingChugLeaderPasswordHashed) && !empty($existingRoshPasswordHashed)) {
+        $roleSelectField .= "<input type=\"radio\" class=\"btn-check\" name=\"role\" id=\"chugleader\" autocomplete=\"off\" value=\"chugleader\">" . 
+        "<label class=\"btn btn-outline-primary\" for=\"chugleader\">Chug Leader</label>" . 
+        "<input type=\"radio\" class=\"btn-check\" name=\"role\" id=\"rosh\" autocomplete=\"off\" value=\"rosh\">" . 
+        "<label class=\"btn btn-outline-primary\" for=\"rosh\">Rosh/Yoetzet</label>";
+    }
+    else if (!empty($existingChugLeaderPasswordHashed)) {
+        $roleSelectField .= "<input type=\"radio\" class=\"btn-check\" name=\"role\" id=\"chugleader\" autocomplete=\"off\" value=\"chugleader\">" . 
+        "<label class=\"btn btn-outline-primary\" for=\"chugleader\">Chug Leader</label>";
+    }
+    else if (!empty($existingRoshPasswordHashed)) {
+        $roleSelectField .= "<input type=\"radio\" class=\"btn-check\" name=\"role\" id=\"rosh\" autocomplete=\"off\" value=\"rosh\">" . 
+        "<label class=\"btn btn-outline-primary\" for=\"rosh\">Rosh/Yoetzet</label>";
+    }
+    $roleSelectField .= "</li>";
+    echo $roleSelectField;
+    $liNum++;
+}
+
+if (empty($existingAdminPasswordHashed)) {
     $emailField = new FormItemSingleTextField("Staff Email Address", true, "staff_email", $liNum++);
     $emailField->setInputValue($staff_email);
     $emailField->setInputType("text");
@@ -162,7 +230,7 @@ $staffPasswordField->setPlaceHolder(" ");
 $staffPasswordField->setGuideText("Enter a staff password.  This password protects the staff-only parts of the page, and should not be shared with campers.");
 echo $staffPasswordField->renderHtml();
 
-if (empty($existingPasswordHashed)) {
+if (empty($existingAdminPasswordHashed)) {
     $staffPasswordField2 = new FormItemSingleTextField("Retype Staff Password", true, "staff_password2", $liNum++);
     $staffPasswordField2->setInputType("password");
     $staffPasswordField2->setInputClass("element text medium");
@@ -173,8 +241,12 @@ if (empty($existingPasswordHashed)) {
 ?>
 
 <li class="buttons">
-<input id="saveForm" class="btn btn-primary" type="submit" name="submit" value="Submit" />
+<input id="saveForm" class="btn btn-primary" type="submit" name="submit" value="Log In" />
 </li>
+    <?php
+    if(!empty($existingAdminPasswordHashed)) {
+        echo ("<li><p><strong>ADMIN ONLY:</strong> if you forgot the password, please click <a href=\"$forgotUrl\">here</a> to reset it.</p></li>");
+    }?>
 </ul>
 <?php
 // Send the query string back, so that we can redirect back if we were sent

--- a/chugbot/staffReset.php
+++ b/chugbot/staffReset.php
@@ -4,6 +4,7 @@ include_once 'functions.php';
 include_once 'formItem.php';
 include_once 'dbConn.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $existingAdminEmail = $admin_email = $existingRegularUserToken = $existingRegularUserTokenHint = $existingCampName = $existingPrefInstructions = $existingCampWeb = $existingAdminEmailCc = $existingAdminEmailFromName = $existingPrefCount = $existingSendConfirmEmail = $existingChugTermSingular = $existingChugTermPlural = $existingBlockTermSingular = $existingBlockTermPlural = "";

--- a/chugbot/staffReset.php
+++ b/chugbot/staffReset.php
@@ -10,7 +10,7 @@ setup_camp_specific_terminology_constants();
 $existingAdminEmail = $admin_email = $existingRegularUserToken = $existingRegularUserTokenHint = $existingCampName = $existingPrefInstructions = $existingCampWeb = $existingAdminEmailCc = $existingAdminEmailFromName = $existingPrefCount = $existingSendConfirmEmail = $existingChugTermSingular = $existingChugTermPlural = $existingBlockTermSingular = $existingBlockTermPlural = "";
 $deletableTableId2Name = array();
 $deletableTableActiveIdHash = array();
-$dbError = $staffPasswordErr = $staffPasswordErr2 = $adminEmailCcErr = $campNameErr = $prefCountError = $campTerminologyErr = "";
+$dbError = $adminPasswordErr = $adminPasswordErr2 = $roshPasswordErr = $roshPasswordErr2 = $chug_leaderPasswordErr = $chug_leaderPasswordErr2 = $adminEmailCcErr = $campNameErr = $prefCountError = $campTerminologyErr = "";
 
 $db = new DbConn();
 $err = "";
@@ -78,7 +78,7 @@ if ($result == false) {
     }
 }
 
-$staffEmailErr = $staffPasswordErr = $staffPasswordErr2 = $existingEmailErr = "";
+$staffEmailErr = $adminPasswordErr = $adminPasswordErr2 = $roshPasswordErr = $roshPasswordErr2 = $chug_leaderPasswordErr = $chug_leaderPasswordErr2 = $existingEmailErr = "";
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $admin_email = test_post_input("admin_email");
     $admin_email_from_name = test_post_input("admin_email_from_name");
@@ -86,8 +86,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $enable_camper_importer = boolval(test_post_input("enable_camper_importer"));
     $enable_camper_creation = boolval(test_post_input("enable_camper_creation"));
     $enable_selection_process = boolval(test_post_input("enable_selection_process"));
-    $staff_password = test_post_input("staff_password");
-    $staff_password2 = test_post_input("staff_password2");
+    $admin_password = test_post_input("admin_password");
+    $admin_password2 = test_post_input("admin_password2");
+    $rosh_password = test_post_input("rosh_password");
+    $rosh_password2 = test_post_input("rosh_password2");
+    $chug_leader_password = test_post_input("chug_leader_password");
+    $chug_leader_password2 = test_post_input("chug_leader_password2");
     $admin_email_cc = test_post_input("admin_email_cc");
     $regular_user_token = test_post_input("regular_user_token");
     $regular_user_token_hint = test_post_input("regular_user_token_hint");
@@ -165,18 +169,44 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             }
         }
     }
-    // Only reset the password if it's explicitly supplied.
-    if ($staff_password) {
-        if (strlen($staff_password) < 5 ||
-            strlen($staff_password) > 255) {
-            $staffPasswordErr = errorString("Password must be between 5 and 255 characters");
+    // Only reset the admin password if it's explicitly supplied.
+    if ($admin_password) {
+        if (strlen($admin_password) < 5 ||
+            strlen($admin_password) > 255) {
+            $adminPasswordErr = errorString("Admin password must be between 5 and 255 characters");
         }
-        if ($staff_password2 != $staff_password) {
+        if ($admin_password2 != $admin_password) {
             // The repeated password must match the first.
-            $staffPasswordErr2 = errorString("Passwords do not match");
+            $adminPasswordErr2 = errorString("Admin passwords do not match");
         }
-        $staffPasswordHashed = password_hash($staff_password, PASSWORD_DEFAULT);
-        $db->addColumn("admin_password", $staffPasswordHashed, 's');
+        $adminPasswordHashed = password_hash($admin_password, PASSWORD_DEFAULT);
+        $db->addColumn("admin_password", $adminPasswordHashed, 's');
+    }
+    // Only reset the rosh password if it's explicitly supplied.
+    if ($rosh_password) {
+        if (strlen($rosh_password) < 5 ||
+            strlen($rosh_password) > 255) {
+            $roshPasswordErr = errorString("Rosh/Yoetzet password must be between 5 and 255 characters");
+        }
+        if ($rosh_password2 != $rosh_password) {
+            // The repeated password must match the first.
+            $roshPasswordErr2 = errorString("Rosh/Yoetzet passwords do not match");
+        }
+        $roshPasswordHashed = password_hash($rosh_password, PASSWORD_DEFAULT);
+        $db->addColumn("rosh_yoetzet_password", $roshPasswordHashed, 's');
+    }
+    // Only reset the chug leader password if it's explicitly supplied.
+    if ($chug_leader_password) {
+        if (strlen($chug_leader_password) < 5 ||
+            strlen($chug_leader_password) > 255) {
+            $chug_leaderPasswordErr = errorString("Chug Leader password must be between 5 and 255 characters");
+        }
+        if ($chug_leader_password2 != $chug_leader_password) {
+            // The repeated password must match the first.
+            $chug_leaderPasswordErr2 = errorString("Chug Leader passwords do not match");
+        }
+        $chug_leaderPasswordHashed = password_hash($chug_leader_password, PASSWORD_DEFAULT);
+        $db->addColumn("chug_leader_password", $chug_leaderPasswordHashed, 's');
     }
     // Same, for pref count.
     if ($pref_count) {
@@ -193,8 +223,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         $campTerminologyErr = errorString("Camp terminologies are required");
     }
     if (empty($staffEmailErr) &&
-        empty($staffPasswordErr) &&
-        empty($staffPasswordErr2) &&
+        empty($adminPasswordErr) &&
+        empty($adminPasswordErr2) &&
+        empty($roshPasswordErr) &&
+        empty($roshPasswordErr2) &&
+        empty($chug_leaderPasswordErr) &&
+        empty($chug_leaderPasswordErr2) &&
         empty($adminEmailCcErr) &&
         empty($dbError) &&
         empty($campNameErr) &&
@@ -206,7 +240,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         if ($updateOk) {
             // New data entered OK: go to the home page.  If a password was
             // validated, log the user in.
-            if ($staff_password) {
+            if ($admin_password) {
                 $_SESSION['admin_logged_in'] = true;
             }
             $redirUrl = urlBaseText() . "staffHome.php?update=as"; // Redir for successful email/pw change.
@@ -221,7 +255,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 <?php
 echo headerText("Edit Admin Data");
 
-$errText = genFatalErrorReport(array($dbError, $staffPasswordErr, $staffPasswordErr2, $staffEmailErr, $adminEmailCcErr, $campNameErr, $prefCountError, $campTerminologyErr));
+$errText = genFatalErrorReport(array($dbError, $adminPasswordErr, $adminPasswordErr2, $roshPasswordErr, $roshPasswordErr2, $chug_leaderPasswordErr, $chug_leaderPasswordErr2, $staffEmailErr, $adminEmailCcErr, $campNameErr, $prefCountError, $campTerminologyErr));
 if (!is_null($errText)) {
     echo $errText;
     exit();
@@ -352,23 +386,143 @@ $campWebField->setInputMaxLength(50);
 $campWebField->setGuideText("Enter your camp website, if you have one, e.g., \"www.campramahne.org\"");
 $campWebField->setPlaceHolder(" ");
 echo $campWebField->renderHtml();
+?>
 
-$staffPasswordField = new FormItemSingleTextField("New Staff Password (leave this field blank to keep staff password the same.)",
-    false, "staff_password", $counter++);
-$staffPasswordField->setInputType("password");
-$staffPasswordField->setInputClass("element text medium");
-$staffPasswordField->setInputMaxLength(50);
-$staffPasswordField->setPlaceHolder(" ");
-$staffPasswordField->setGuideText("Leave this field and the next one blank if you do not wish to change the admin password.");
-echo $staffPasswordField->renderHtml();
+<li>
+<label class="description mt-2" for="passwordChangeAccordion">
+    Update Password(s)
+</label>
+Update any number of passwords in the applicable sections of the accordion below. Passwords must be between 5-255 characters.
+<div class="accordion" id="passwordChangeAccordion">
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="headingAdmin">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAdmin" aria-expanded="true" aria-controls="collapseAdmin">
+                Admin Password
+            </button>
+        </h2>
+        <div id="collapseAdmin" class="accordion-collapse collapse show" aria-labelledby="headingAdmin" data-bs-parent="#accordionExample">
+            <div class="accordion-body">
+                <?php
+                $adminPasswordField = new FormItemSingleTextField("New Admin Password (leave this field blank to keep admin password the same.)",
+                    false, "admin_password", $counter++);
+                $adminPasswordField->setInputType("password");
+                $adminPasswordField->setInputClass("element text medium");
+                $adminPasswordField->setInputMaxLength(50);
+                $adminPasswordField->setPlaceHolder(" ");
+                $adminPasswordField->setGuideText("Leave this field and the next one blank if you do not wish to change the admin password.");
+                
+                $adminPasswordStr = $adminPasswordField->renderHtml();
 
-$staffPasswordField2 = new FormItemSingleTextField("Retype New Staff Password", false, "staff_password2", $counter++);
-$staffPasswordField2->setInputType("password");
-$staffPasswordField2->setInputClass("element text medium");
-$staffPasswordField2->setInputMaxLength(50);
-$staffPasswordField2->setPlaceHolder(" ");
-echo $staffPasswordField2->renderHtml();
+                // change from list element to just regular div with same id
+                $adminPasswordStr = str_replace("<li", "<div class=\"mb-3\"", $adminPasswordStr);
+                $adminPasswordStr = str_replace("/li>", "/div>", $adminPasswordStr);
 
+                echo $adminPasswordStr;
+
+                $adminPasswordField2 = new FormItemSingleTextField("Retype New Admin Password", false, "admin_password2", $counter++);
+                $adminPasswordField2->setInputType("password");
+                $adminPasswordField2->setInputClass("element text medium");
+                $adminPasswordField2->setInputMaxLength(50);
+                $adminPasswordField2->setPlaceHolder(" ");
+
+                $adminPassword2Str = $adminPasswordField2->renderHtml();
+
+                // change from list element to just regular div with same id
+                $adminPassword2Str = str_replace("<li", "<div", $adminPassword2Str);
+                $adminPassword2Str = str_replace("/li>", "/div>", $adminPassword2Str);
+
+                echo $adminPassword2Str;
+                ?>
+            </div>
+        </div>
+    </div>
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="headingRosh">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRosh" aria-expanded="false" aria-controls="collapseRosh">
+                Rosh Edah/Yoetzet Password
+            </button>
+        </h2>
+        <div id="collapseRosh" class="accordion-collapse collapse" aria-labelledby="headingRosh" data-bs-parent="#passwordChangeAccordion">
+            <div class="accordion-body">
+            <?php
+                $roshPasswordField = new FormItemSingleTextField("New Rosh/Yoetzet Password (leave this field blank to keep rosh/yoetzet password the same.)",
+                    false, "rosh_password", $counter++);
+                $roshPasswordField->setInputType("password");
+                $roshPasswordField->setInputClass("element text medium");
+                $roshPasswordField->setInputMaxLength(50);
+                $roshPasswordField->setPlaceHolder(" ");
+                $roshPasswordField->setGuideText("Leave this field and the next one blank if you do not wish to change the rosh/yoetzet password.");
+                
+                $roshPasswordStr = $roshPasswordField->renderHtml();
+
+                // change from list element to just regular div with same id
+                $roshPasswordStr = str_replace("<li", "<div class=\"mb-3\"", $roshPasswordStr);
+                $roshPasswordStr = str_replace("/li>", "/div>", $roshPasswordStr);
+
+                echo $roshPasswordStr;
+
+                $roshPasswordField2 = new FormItemSingleTextField("Retype New Rosh/Yoetzet Password", false, "rosh_password2", $counter++);
+                $roshPasswordField2->setInputType("password");
+                $roshPasswordField2->setInputClass("element text medium");
+                $roshPasswordField2->setInputMaxLength(50);
+                $roshPasswordField2->setPlaceHolder(" ");
+
+                $roshPassword2Str = $roshPasswordField2->renderHtml();
+
+                // change from list element to just regular div with same id
+                $roshPassword2Str = str_replace("<li", "<div", $roshPassword2Str);
+                $roshPassword2Str = str_replace("/li>", "/div>", $roshPassword2Str);
+
+                echo $roshPassword2Str;
+                ?>
+            </div>
+        </div>
+    </div>
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="headingChugLeader">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseChugLeader" aria-expanded="false" aria-controls="collapseChugLeader">
+                Chug Leader Password
+            </button>
+        </h2>
+        <div id="collapseChugLeader" class="accordion-collapse collapse" aria-labelledby="headingChugLeader" data-bs-parent="#passwordChangeAccordion">
+            <div class="accordion-body">
+            <?php
+                $chugLeaderPasswordField = new FormItemSingleTextField("New " . ucfirst($chug_term_singular) . " Leader Password (leave this field blank to keep $chug_term_singular leader password the same.)",
+                    false, "chug_leader_password", $counter++);
+                $chugLeaderPasswordField->setInputType("password");
+                $chugLeaderPasswordField->setInputClass("element text medium");
+                $chugLeaderPasswordField->setInputMaxLength(50);
+                $chugLeaderPasswordField->setPlaceHolder(" ");
+                $chugLeaderPasswordField->setGuideText("Leave this field and the next one blank if you do not wish to change the $chug_term_singular leader password.");
+                
+                $chugLeaderPasswordStr = $chugLeaderPasswordField->renderHtml();
+
+                // change from list element to just regular div with same id
+                $chugLeaderPasswordStr = str_replace("<li", "<div class=\"mb-3\"", $chugLeaderPasswordStr);
+                $chugLeaderPasswordStr = str_replace("/li>", "/div>", $chugLeaderPasswordStr);
+
+                echo $chugLeaderPasswordStr;
+
+                $chugLeaderPasswordField2 = new FormItemSingleTextField("Retype New " . ucfirst($chug_term_singular) . " Leader Password", false, "chug_leader_password2", $counter++);
+                $chugLeaderPasswordField2->setInputType("password");
+                $chugLeaderPasswordField2->setInputClass("element text medium");
+                $chugLeaderPasswordField2->setInputMaxLength(50);
+                $chugLeaderPasswordField2->setPlaceHolder(" ");
+
+                $chugLeaderPassword2Str = $chugLeaderPasswordField2->renderHtml();
+
+                // change from list element to just regular div with same id
+                $chugLeaderPassword2Str = str_replace("<li", "<div", $chugLeaderPassword2Str);
+                $chugLeaderPassword2Str = str_replace("/li>", "/div>", $chugLeaderPassword2Str);
+
+                echo $chugLeaderPassword2Str;
+                ?>
+            </div>
+        </div>
+    </div>
+</div></li>
+
+<?php
 $chugTermSingularField = new FormItemSingleTextField("Chug Term (singular)", false, "chug_term_singular", $counter++);
 $chugTermSingularField->setInputType("text");
 $chugTermSingularField->setInputClass("element text medium");

--- a/chugbot/viewCampersByEdah.php
+++ b/chugbot/viewCampersByEdah.php
@@ -3,6 +3,7 @@ session_start();
 include_once 'dbConn.php';
 include_once 'functions.php';
 bounceToLogin();
+checkLogout();
 setup_camp_specific_terminology_constants();
 
 $dbErr = "";


### PR DESCRIPTION
### Description
Creates a way for chug leaders to use ChugBot to see live, up to date attendance sheets and take attendance for the chugim they are running. Also provides a mechanism for roshes/yoetzot to review attendance and quickly communicate which campers are missing to their staff, as well as track some attendance trends throughout the summer. The administrator must designate which time blocks are active for a given chug group, and then other tzevet may begin taking attendance.

### Specific Features
- Creates chug leader and rosh edah logins, enabling access to virtual attendance system
    - Customizes the navigation bar for different user-access levels
- Chug leader searches for edah/edot and chug through a simple form on their own designated home page
- Chug leader can press checkmarks to then indicate which campers are present (with a toggle all button available), and save their selections using a button at the base of the screen
- Rosh/yoetzet has option to view the attendance of one perek (default) or detailed matrix with historical data
    - Regardless, searches for the specific options through a similarly simple/intuitive form
- Perek Attendance View: Rosh/yoetzet sees list of campers sorted by edah, bunk, and then name. Also shows what chug they are supposed to be in and their current status (present, absent, attendance not yet taken) both by color and an icon
    - Ability to press a button below the attendance to automatically copy a simply-formatted plaintext attendance report to device clipboard, facilitating easy communication to other members of the staff
- Matrix Attendance View: Rosh/yoetzet sees list of campers in one edah with their historic attendance records (bound by provided dates) to identify trends in missing campers
    - One row per camper with one column per date, and an icon in the corresponding cell indicating the attendance of that camper on that date
    - 1 attendance matrix per chug group with attendance records within the provided dates
- Admin ability to designate which block is active for a chug group (and therefore ability to release chug lists once they are finalized)
- Admin ability to purge old attendance records (e.g. delete ones from previous sessions or summers)
- Other minor changes/updates as needed

### Testing Instructions
In the directory where the repo is stored locally, run this command:
```
./start.sh
```
Then, navigate to [http://127.0.0.1:8000/](http://127.0.0.1:8000/) on that device and test normally. No coding should be required for basic testing.

By default, the testing database sets the rosh password to "developerrosh" and the chug leader password to "developerchug" (though can [and for thorough testing, should] be changed through the main admin settings page) All chug groups are set to have "Session A" as the active block. No attendance records are provided; the tester must "take attendance" from scratch.

### Installation/Upgrade Instructions
This update requires 2 new tables in the database:
- `attendance` - creates a record for every camper who has attendance taken (`camper_id`, `date`, `chug_instance_id`, `attendance_id`, `present`)
- `attendance_block_by_date` - identifies the block which is active for a particular date and chug group, keeping a record of information to accurately retrieve historical attendance lists
It also requires a few additional columns in other tables:
- `active_block_id` in `chug_groups` table tracks the block which is active for a particular chug group (perek)
- `chug_leader_password` and `rosh_yoetzet_password` in `admin_data` hold hashed passwords to be matched against their respective roles.

To complete these updates on the live databases of the real, running application, sign into the SQL server, select the correct database, and run the following to create the structure which will be populated as the application runs:
```
--
-- Table structure for table `attendance`
--

DROP TABLE IF EXISTS `attendance`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!50503 SET character_set_client = utf8mb4 */;
CREATE TABLE `attendance` (
  `camper_id` int NOT NULL,
  `date` date NOT NULL,
  `chug_instance_id` int NOT NULL,
  `attendance_id` int NOT NULL AUTO_INCREMENT,
  `present` tinyint NOT NULL,
  PRIMARY KEY (`attendance_id`),
  UNIQUE KEY `uk_attendance_present` (`camper_id`,`date`,`chug_instance_id`),
  CONSTRAINT `attendance_present_ibfk_1` FOREIGN KEY (`camper_id`) REFERENCES `campers` (`camper_id`) ON DELETE CASCADE ON UPDATE CASCADE,
  CONSTRAINT `attendance_present_ibfk_2` FOREIGN KEY (`chug_instance_id`) REFERENCES `chug_instances` (`chug_instance_id`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
/*!40101 SET character_set_client = @saved_cs_client */;


--
-- Table structure for table `attendance_block_by_date`
--

DROP TABLE IF EXISTS `attendance_block_by_date`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!50503 SET character_set_client = utf8mb4 */;
CREATE TABLE `attendance_block_by_date` (
  `date` date NOT NULL,
  `group_id` int NOT NULL,
  `block_id` int NOT NULL,
  `attendance_block_by_date_id` int NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`attendance_block_by_date_id`),
  UNIQUE KEY `uk_attendance_block_by_date` (`date`,`group_id`),
  CONSTRAINT `attendance_block_by_date_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `chug_groups` (`group_id`) ON DELETE CASCADE ON UPDATE CASCADE,
  CONSTRAINT `attendance_block_by_date_ibfk_2` FOREIGN KEY (`block_id`) REFERENCES `blocks` (`block_id`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
/*!40101 SET character_set_client = @saved_cs_client */;

alter table chug_groups add active_block_id INTEGER, add constraint foreign key(active_block_id) references blocks(block_id);

alter table admin_data add chug_leader_password varchar(255), add rosh_yoetzet_password varchar(255);
```