### PR TITLE
Admin Leveling Updates + PHP 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-apache
+FROM php:8.3-apache
 
 RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli
 RUN apt-get update && apt-get upgrade -y

--- a/chugbot/.platform/hooks/postdeploy/00_get_certificate.sh
+++ b/chugbot/.platform/hooks/postdeploy/00_get_certificate.sh
@@ -14,6 +14,8 @@ elif [[ $ENV == "Chugbotbos-env" ]]; then
   DOMAIN="bos.campramahchug.org"
 elif [[ $ENV == "Chugbotrr-env" ]]; then
   DOMAIN="rr.campramahchug.org"
+elif [[ $ENV == "Chugbotla-env" ]]; then
+  DOMAIN="la.campramahchug.org"
 else
   DOMAIN="test.campramahchug.org"
 fi

--- a/chugbot/addEdit.php
+++ b/chugbot/addEdit.php
@@ -241,6 +241,11 @@ EOM;
             $saveAndReturnText = "<input id=\"saveAndReturn\" class=\"btn btn-primary\" type=\"submit\" name=\"saveAndReturn\" value=\"$label\" />";
         }
         if ($this->editPage) {
+            if(!isset($this->col2Val[$this->idCol])) {
+                // if we are on an edit page, something should be edited;
+                // if no value was selected, exit
+                exit();
+            }
             $val = $this->col2Val[$this->idCol];
             if ((!$val) &&
                 (!is_null($this->constantIdValue))) {

--- a/chugbot/ajax.php
+++ b/chugbot/ajax.php
@@ -167,7 +167,9 @@ if (isset($_POST["submit_prefs"])) {
         $db->addColumn("first", $_SESSION["first"], 's');
         $db->addColumn("last", $_SESSION["last"], 's');
         $db->addColumn("email", $_SESSION["email"], 's');
-        $db->addColumn("email2", $_SESSION["email2"], 's');
+        if (isset($_SESSION["email2"])) {
+            $db->addColumn("email2", $_SESSION["email2"], 's');
+        }
         $db->addColumn("session_id", intval($_SESSION["session_id"]), 'i');
         $db->addColumn("edah_id", intval($_SESSION["edah_id"]), 'i');
         $bunkIdVal = null;

--- a/chugbot/attendance/index.php
+++ b/chugbot/attendance/index.php
@@ -116,7 +116,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 exit();
             }
             // 2b: delete that attendance was taken for that perek
-            $sql = "DELETE FROM chug_attendance_taken WHERE date < '$date'";
+            $sql = "DELETE FROM attendance_block_by_date WHERE date < '$date'";
             $result = $dbc->doQuery($sql, $localErr);
             if ($result == false) {
                 echo dbErrorString($sql, $localErr);

--- a/chugbot/attendance/takeAttendance.php
+++ b/chugbot/attendance/takeAttendance.php
@@ -176,7 +176,7 @@
                 $selected = "checked=checked";
             }
             $att .= "<label class=\"form-check-label\"><input class=\"form-check-input ms-2 me-1 att-child\" type=\"checkbox\"" .  
-                    "name=\"present[]\" value=\"${row[0]}\" id=\"\" $selected>$row[1]</label>";
+                    "name=\"present[]\" value=\"{$row[0]}\" id=\"\" $selected>$row[1]</label>";
         }
 
         $attendanceSection = "<div class=\"card card-body bg-light mt-3 mb-3 edah-attendance\">";

--- a/chugbot/attendance/viewAttendanceMatrix.php
+++ b/chugbot/attendance/viewAttendanceMatrix.php
@@ -171,17 +171,17 @@
                     // determine unique data for this camper and day
                     $tooltipText = $icon = $class = "";
                     if(is_null($row[$i])) { // attendance not yet taken
-                        $tooltipText = "<b>Attendance Not Taken</b><br><b>" . ucfirst(chug_term_singular) . ":</b>${row[$i+1]}";
+                        $tooltipText = "<b>Attendance Not Taken</b><br><b>" . ucfirst(chug_term_singular) . ":</b>{$row[$i+1]}";
                         $icon = "<i class=\"bi bi-exclamation-triangle\"></i>";
                         $class = "table-warning";
                     }
                     else if($row[$i] == 0) { // absent
-                        $tooltipText = "<b>Absent</b><br><b>" . ucfirst(chug_term_singular) . ":</b>${row[$i+1]}";
+                        $tooltipText = "<b>Absent</b><br><b>" . ucfirst(chug_term_singular) . ":</b>{$row[$i+1]}";
                         $icon = "<i class=\"bi bi-x-circle-fill\"></i>";
                         $class = "table-danger";
                     }
                     else if ($row[$i] == 1) { // present
-                        $tooltipText = "<b>Present</b><br><b>" . ucfirst(chug_term_singular) . ":</b>${row[$i+1]}";
+                        $tooltipText = "<b>Present</b><br><b>" . ucfirst(chug_term_singular) . ":</b>{$row[$i+1]}";
                         $icon = "<i class=\"bi bi-check-circle\"></i>";
                     }
 

--- a/chugbot/exclusionMatrix.html
+++ b/chugbot/exclusionMatrix.html
@@ -19,9 +19,9 @@
   <script src="meta/matrix.js"></script>
   <link rel="stylesheet" type="text/css"
     href="https://cdn.datatables.net/u/dt/jqc-1.12.3,dt-1.10.12,fc-3.2.2,fh-3.1.2/datatables.min.css" />
-<script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" 
-    integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>
+  <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" 
+    integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" 
     integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous"></head>
     <link href="https://cdn.datatables.net/2.1.8/css/dataTables.bootstrap5.css" rel="stylesheet">

--- a/chugbot/formItem.php
+++ b/chugbot/formItem.php
@@ -220,7 +220,7 @@ class FormItemInstanceChooser extends FormItem
         $idString = "form_item_instance_chooser_" . $num;
         $javascript = <<<JSEND
             <script>
-            function toggle${num}(source) {
+            function toggle{$num}(source) {
                 var checkboxes = $("#$idString").find(":input");
                 for (var i = 0; i < checkboxes.length; i++) {
                     var checkbox = checkboxes[i];
@@ -230,7 +230,7 @@ class FormItemInstanceChooser extends FormItem
             </script>
 JSEND;
         $this->html .= "$javascript \n";
-        $this->html .= "<label class=\"form-check-label\"><input class=\"form-check-input me-1\" type=\"checkbox\" onClick=\"toggle${num}(this)\">Toggle All</label><br>";
+        $this->html .= "<label class=\"form-check-label\"><input class=\"form-check-input me-1\" type=\"checkbox\" onClick=\"toggle{$num}(this)\">Toggle All</label><br>";
         $this->html .= "<div class=\"form_item_instance_chooser card card-body bg-light\" id=\"$idString\" >\n";
         $this->html .= genCheckBox($this->id2Name, $this->activeIdHash, $this->inputName);
         $this->html .= "</div>";
@@ -340,7 +340,7 @@ class FormItemDropDown extends FormItem
                 button.setAttribute('aria-label', 'Close');
 
                 input.type = 'hidden';
-                input.name = "${name}[]";
+                input.name = "{$name}[]";
                 input.value = option.value;
 
                 li.appendChild(input);
@@ -429,9 +429,9 @@ class FormItemConstrainedDropDown extends FormItem
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
 <script>
 function fillConstraints() {
-    var parent = $("#${parentId}");
+    var parent = $("#{$parentId}");
     var parentName = "$parentName";
-    var ourDropDown = $("#${ourId}");
+    var ourDropDown = $("#{$ourId}");
     var selected = "$ourCurrentValue";
     var values = {};
     values["get_legal_id_to_name"] = 1;
@@ -483,8 +483,8 @@ function fillConstraints() {
     });
 }
 $(function() {
-  $("select#${parentId}").load(fillConstraints());
-  $("select#${parentId}").bind('change',fillConstraints);
+  $("select#{$parentId}").load(fillConstraints());
+  $("select#{$parentId}").bind('change',fillConstraints);
 });
 
 </script>

--- a/chugbot/fpdf/fpdf.php
+++ b/chugbot/fpdf/fpdf.php
@@ -232,31 +232,31 @@ function SetCompression($compress)
 function SetTitle($title, $isUTF8=false)
 {
 	// Title of document
-	$this->metadata['Title'] = $isUTF8 ? $title : utf8_encode($title);
+	$this->metadata['Title'] = $isUTF8 ? $title : mb_convert_encoding($title, "UTF-8");
 }
 
 function SetAuthor($author, $isUTF8=false)
 {
 	// Author of document
-	$this->metadata['Author'] = $isUTF8 ? $author : utf8_encode($author);
+	$this->metadata['Author'] = $isUTF8 ? $author : mb_convert_encoding($author, "UTF-8");
 }
 
 function SetSubject($subject, $isUTF8=false)
 {
 	// Subject of document
-	$this->metadata['Subject'] = $isUTF8 ? $subject : utf8_encode($subject);
+	$this->metadata['Subject'] = $isUTF8 ? $subject : mb_convert_encoding($subject, "UTF-8");
 }
 
 function SetKeywords($keywords, $isUTF8=false)
 {
 	// Keywords of document
-	$this->metadata['Keywords'] = $isUTF8 ? $keywords : utf8_encode($keywords);
+	$this->metadata['Keywords'] = $isUTF8 ? $keywords : mb_convert_encoding($keywords, "UTF-8");
 }
 
 function SetCreator($creator, $isUTF8=false)
 {
 	// Creator of document
-	$this->metadata['Creator'] = $isUTF8 ? $creator : utf8_encode($creator);
+	$this->metadata['Creator'] = $isUTF8 ? $creator : mb_convert_encoding($creator, "UTF-8");
 }
 
 function AliasNbPages($alias='{nb}')
@@ -662,7 +662,11 @@ function MultiCell($w, $h, $txt, $border=0, $align='J', $fill=false)
 	if($w==0)
 		$w = $this->w-$this->rMargin-$this->x;
 	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
-	$s = str_replace("\r",'',$txt);
+	if (!empty($txt)) {
+		$s = str_replace("\r", '', $txt);
+	} else {
+		$s = "";
+	}
 	$nb = strlen($s);
 	if($nb>0 && $s[$nb-1]=="\n")
 		$nb--;

--- a/chugbot/functions.php
+++ b/chugbot/functions.php
@@ -387,7 +387,7 @@ function genCheckBox($id2Name, $activeIds, $arrayName)
             array_key_exists($idStr, $activeIds)) {
             $selStr = "checked=checked";
         }
-        $retVal .= "<label class=\"form-check-label\"><input class=\"form-check-input me-1\" type=\"checkbox\" name=\"${arrayName}[]\" value=\"$idStr\" id=\"${arrayName}_$idStr\" $selStr>$name</label>";
+        $retVal .= "<label class=\"form-check-label\"><input class=\"form-check-input me-1\" type=\"checkbox\" name=\"{$arrayName}[]\" value=\"$idStr\" id=\"{$arrayName}_$idStr\" $selStr>$name</label>";
     }
     return $retVal;
 }
@@ -402,13 +402,13 @@ function genConstrainedCheckBoxScript($id2Name, $arrayName,
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
 <script>
 function fillConstraintsCheckBox() {
-    var parent = $("#${parentId}");
-    var ourCheckBox = $("#${ourId}");
-    var ourDesc = $("#${descId}");
+    var parent = $("#{$parentId}");
+    var ourCheckBox = $("#{$ourId}");
+    var ourDesc = $("#{$descId}");
     var values = {};
     values["get_legal_id_to_name"] = 1;
     var curSelectedEdahIds = [];
-    $("#${parentId} input:checked").each(function() {
+    $("#{$parentId} input:checked").each(function() {
        curSelectedEdahIds.push($(this).attr('value'));
     });
     var sql = "SELECT e.group_id group_id, g.name group_name FROM edot_for_group e, chug_groups g WHERE e.edah_id IN (";
@@ -444,7 +444,7 @@ function fillConstraintsCheckBox() {
                return;
            }
            $.each(data, function(itemId, itemName) {
-                html = "<label class=\"form-check-label\"><input class=\"form-check-input me-1\" type=\"checkbox\" name=\"" + "${arrayName}" +
+                html = "<label class=\"form-check-label\"><input class=\"form-check-input me-1\" type=\"checkbox\" name=\"" + "{$arrayName}" +
                   "[]\" value=\"" + itemId + "\" checked=checked/>" + itemName + "</label>";
                 $(ourCheckBox).append(html);
             });
@@ -458,8 +458,8 @@ function fillConstraintsCheckBox() {
     });
 }
 $(function() {
-  $("#${parentId}").load(fillConstraintsCheckBox());
-  $("#${parentId}").bind('change',fillConstraintsCheckBox);
+  $("#{$parentId}").load(fillConstraintsCheckBox());
+  $("#{$parentId}").bind('change',fillConstraintsCheckBox);
 });
 </script>
 JS;
@@ -479,32 +479,32 @@ function genConstrainedPickListScript($ourId, $parentId, $descId, $type, $choice
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
 <script>
 function fillConstraintsPickList() {
-    var parent = $("#${parentId}");
-    var ourPickList = $("#${ourId}");
-    var ourDesc = $("#${descId}");
+    var parent = $("#{$parentId}");
+    var ourPickList = $("#{$ourId}");
+    var ourDesc = $("#{$descId}");
     var values = {};
     values["get_legal_id_to_name"] = 1;
     $(ourDesc).hide();
-    if(!${choicesJS}) {
-        var parentField = document.getElementsByName("${parentId}")[0];
+    if(!{$choicesJS}) {
+        var parentField = document.getElementsByName("{$parentId}")[0];
     }
     else {
-        var parentField = document.getElementsByName("${parentId}[]")[0];
+        var parentField = document.getElementsByName("{$parentId}[]")[0];
     }
     var curSelectedEdahIds = [];
     for (var option of parentField.selectedOptions) {
         curSelectedEdahIds.push(option.value);
     }
-    if("${type}" == "group" || "${type}" == "block" || "${type}" == "schedule") {
-        var sql = "SELECT e.${type}_id ${type}_id, g.name ${type}_name FROM edot_for_${type} e, "
+    if("{$type}" == "group" || "{$type}" == "block" || "{$type}" == "schedule") {
+        var sql = "SELECT e.{$type}_id {$type}_id, g.name {$type}_name FROM edot_for_{$type} e, "
         // Determine right table to search from
-        if ("${type}" == "group") {
+        if ("{$type}" == "group") {
             sql += "chug_groups g WHERE e.edah_id IN (";
         }
-        else if ("${type}" == "block") {
+        else if ("{$type}" == "block") {
             sql += "blocks g WHERE e.edah_id IN (";
         }
-        else if ("${type}" == "schedule") {
+        else if ("{$type}" == "schedule") {
             sql += "schedules g WHERE e.edah_id IN (";
         }
         var ct = 0;
@@ -514,11 +514,11 @@ function fillConstraintsPickList() {
             }
             sql += "?";
         }
-        sql += ") AND e.${type}_id = g.${type}_id ";
-        if("${type}" == "group" && $("#${choicesJS}")) {
+        sql += ") AND e.{$type}_id = g.{$type}_id ";
+        if("{$type}" == "group" && $("#{$choicesJS}")) {
             sql += "AND active_block_id IS NOT NULL ";
         }
-        sql += "GROUP BY e.${type}_id HAVING COUNT(e.edah_id) = " + ct;
+        sql += "GROUP BY e.{$type}_id HAVING COUNT(e.edah_id) = " + ct;
     }
     if(ourPickList === "edah") {
         sql += " SORT BY e.sort_order";
@@ -542,17 +542,17 @@ function fillConstraintsPickList() {
             $(ourDesc).hide();
             return;
         }
-        if(!$("#${choicesJS}")) {
-            html = "<select class=\"form-select\" id=\"${ourId}\" name=\"${type}\" required";
+        if(!$("#{$choicesJS}")) {
+            html = "<select class=\"form-select\" id=\"{$ourId}\" name=\"{$type}\" required";
         }
         else {
-            html = "<select class=\"form-select choices-js\" id=\"${ourId}\" name=\"${type}\"";
+            html = "<select class=\"form-select choices-js\" id=\"{$ourId}\" name=\"{$type}\"";
         }
 
-        if ("${type}" == "schedule") {
+        if ("{$type}" == "schedule") {
             html += " onchange=\"loadSchedule()\"> <option value=\"\"> -- New Schedule -- </option>";
         }
-        else if ("${type}" == "group") {
+        else if ("{$type}" == "group") {
             if(typeof fillChugimConstraintsPickList === "function") {
                 html += " onchange=\"fillChugimConstraintsPickList()\"> <option value=\"\"> -- Choose Perek -- </option>";
             }
@@ -570,7 +570,7 @@ function fillConstraintsPickList() {
         $(ourPickList).append(html);
         $(ourPickList).show();
         $(ourDesc).show();
-        if(${choicesJS}) {
+        if({$choicesJS}) {
             const choices = new Choices($(ourPickList).find('select')[0], {shouldSort: false, allowHTML: true, searchEnabled: false});
         }
         },
@@ -581,8 +581,8 @@ function fillConstraintsPickList() {
     });
 }
 $(function() {
-  $("#${parentId}").load(fillConstraintsPickList());
-  $("#${parentId}").bind('change',fillConstraintsPickList);
+  $("#{$parentId}").load(fillConstraintsPickList());
+  $("#{$parentId}").bind('change',fillConstraintsPickList);
 });
 </script>
 JS;
@@ -597,18 +597,18 @@ function genChugimPickListScript($ourId, $parent1, $parent2, $descId, $type, $ch
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
 <script>
 function fillChugimConstraintsPickList() {
-    var parent1 = $("#${parent1}");
-    var parent2 = $("#${parent2}");
-    var ourPickList = $("#${ourId}");
-    var ourDesc = $("#${descId}");
+    var parent1 = $("#{$parent1}");
+    var parent2 = $("#{$parent2}");
+    var ourPickList = $("#{$ourId}");
+    var ourDesc = $("#{$descId}");
     var values = {};
     values["get_legal_id_to_name"] = 1;
     $(ourDesc).hide();
     $(ourPickList).hide();
 
     // perform basic sanity checks to ensure the two parent fields (edah, group) have valid values
-    var parent1Field = document.getElementsByName("${parent1}[]")[0];
-    var parent2Field = document.getElementsByName("${parent2}");
+    var parent1Field = document.getElementsByName("{$parent1}[]")[0];
+    var parent2Field = document.getElementsByName("{$parent2}");
     if(parent2Field.length < 1) { return; } // verifies there is a value present for group; if not, end
     parent2Field = parent2Field[0];
     var instanceIds = [];
@@ -619,7 +619,7 @@ function fillChugimConstraintsPickList() {
     }
     if(parent1Field.selectedOptions.length < 1) { return; } // ensures 1+ edot are selected before continuing
 
-    if("${type}" == "chug") {
+    if("{$type}" == "chug") {
         // sql statement looks for all chugim which apply to any number of the selected edot for given chug group and active block
         var sql = "SELECT e.chug_id, c.name FROM edot_for_chug e JOIN (SELECT c.chug_id, c.name FROM chug_instances i ";
         sql += "JOIN chugim c ON i.chug_id = c.chug_id WHERE i.block_id = (SELECT active_block_id FROM chug_groups WHERE group_id = ?) AND c.group_id = ?) c "
@@ -653,17 +653,17 @@ function fillChugimConstraintsPickList() {
             $(ourDesc).hide();
             return;
         }
-        if(!$("#${choicesJS}")) {
-            html = "<select class=\"form-select\" id=\"${ourId}\" name=\"${type} required\"";
+        if(!$("#{$choicesJS}")) {
+            html = "<select class=\"form-select\" id=\"{$ourId}\" name=\"{$type} required\"";
         }
         else {
-            html = "<select class=\"form-select choices-js\" id=\"${ourId}\" name=\"${type}\"";
+            html = "<select class=\"form-select choices-js\" id=\"{$ourId}\" name=\"{$type}\"";
         }
 
-        if ("${type}" == "schedule") {
+        if ("{$type}" == "schedule") {
             html += " onchange=\"loadSchedule()\"> <option value=\"\"> -- New Schedule -- </option>";
         }
-        else if ("${type}" == "chug") {
+        else if ("{$type}" == "chug") {
             html += " onchange=\"\"> <option value=\"\"> -- Choose Chug -- </option>";
         }
         else {
@@ -676,7 +676,7 @@ function fillChugimConstraintsPickList() {
         $(ourPickList).append(html);
         $(ourPickList).show();
         $(ourDesc).show();
-        if($("#${choicesJS}")) {
+        if($("#{$choicesJS}")) {
             const choices = new Choices($(ourPickList).find('select')[0], {shouldSort: true, allowHTML: true});
         }
         },
@@ -687,10 +687,10 @@ function fillChugimConstraintsPickList() {
     });
 }
 $(function() {
-  $("#${parent1}").load(fillChugimConstraintsPickList());
-  $("#${parent1}").bind('change',fillChugimConstraintsPickList);
-  $("#${parent2}").load(fillChugimConstraintsPickList());
-  $("#${parent2}").bind('change',fillChugimConstraintsPickList);
+  $("#{$parent1}").load(fillChugimConstraintsPickList());
+  $("#{$parent1}").bind('change',fillChugimConstraintsPickList);
+  $("#{$parent2}").load(fillChugimConstraintsPickList());
+  $("#{$parent2}").bind('change',fillChugimConstraintsPickList);
 });
 </script>
 JS;
@@ -885,7 +885,9 @@ function staffBounceBackUrl()
     $parts = array();
     $qs = htmlspecialchars($_SERVER['QUERY_STRING']);
     $qs_from_post = test_post_input('query_string');
-    $qs_from_post = preg_replace("/&#?[a-z0-9]+;/i", "", $qs_from_post);
+    if (!empty($qs_from_post)) {
+        $qs_from_post = preg_replace("/&#?[a-z0-9]+;/i", "", $qs_from_post);
+    }
     if (!empty($qs)) {
         $parts = explode("/", $qs);
     } else if (!empty($qs_from_post)) {

--- a/chugbot/levelHome.html
+++ b/chugbot/levelHome.html
@@ -18,8 +18,8 @@
     integrity="sha256-AAhU14J4Gv8bFupUUcHaPQfvrdNauRHMt+S4UVcaJb0=" crossorigin="anonymous"></script>
   <script src="meta/leveling.js"></script>
   <link rel="stylesheet" href="meta/view.css" />
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" 
-    integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" 
+    integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" 
     integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous"></head>
   <style>
@@ -52,8 +52,8 @@
       -webkit-border-radius: 5px;
     }
 
-    .chugholder li h5 {
-      margin: 0 0 0.4em;
+    .chugholder li {
+      margin: 0 0 0.4em 0.4em;
       cursor: move;
     }
 
@@ -75,6 +75,39 @@
 
     .li_no_pref {
       border-color: #ef60ff;
+    }
+
+    .tooltip-inner ol {
+      margin-bottom: 0px;
+      padding-left: 1.5rem;
+    }
+    .context-menu {
+      display: none;
+      position: absolute;
+      background: white;
+      border: 1px solid #ccc;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      z-index: 1000;
+    }
+
+    .context-menu ul {
+      list-style: none;
+      padding: 5px;
+      margin: 0;
+    }
+
+    .context-menu ul li {
+      padding: 5px 10px;
+      cursor: pointer;
+    }
+
+    .context-menu ul li:hover {
+      background: #f0f0f0;
+    }
+
+    .inner.accordion-button:not(.collapsed) {
+      color: var(--bs-info-active-color);
+      background-color: var(--bs-info-bg-subtle);
     }
   </style>
 
@@ -112,7 +145,7 @@
       <li>To design custom schedules with each camper's saved <span class="chugfill">CHUG</span> assignments, click <b>Design Schedules</b>.
     </ul>
   </div>
-  <div class="toggler p-1">
+  <div class="toggler">
     <div id="results" style="display:none">
     </div>
   </div>
@@ -133,6 +166,15 @@
   <div class="card card-body mt-3 mb-3 pb-0 container">
     <div id="fillmatches"></div>
   </div>
+
+  <div id="context-menu" class="context-menu">
+    <ul id="context-menu-options"></ul>
+  </div>
+
+  <div id="toast-container" class="position-fixed bottom-0 end-0 p-3" style="z-index: 1100;">
+    <!-- Toasts will be appended here dynamically -->
+  </div>
+
 
 </body>
 

--- a/chugbot/levelHome.html
+++ b/chugbot/levelHome.html
@@ -119,30 +119,52 @@
 
   <div class="card card-body mt-3 p-3 container">
     <h2>Welcome to the Leveling Page!</h2>
-    <h2><span class="edahtermbothfill">EDAH_TERM_COMBO:</span><span class="edahfill"> EDAH</span></h2>
-    <h2><span class="blocktermfill">Time BLOCK_TERM:</span><span class="blockfill"> BLOCK</span></h2>
-    <p>This page displays suggested <span class="chugfill">CHUG</span> assignments for one <span class="edahtermfill">EDAH_TERM:</span> in a time
+    <h3><span class="edahtermbothfill">EDAH_TERM_COMBO:</span><span class="edahfill"> EDAH</span></h2>
+    <h3><span class="blocktermfill">Time BLOCK_TERM:</span><span class="blockfill"> BLOCK</span></h2>
+    <p>This page displays <span class="chugfill">CHUG</span> assignments for the selected <span class="edahtermbothfill">EDAH_TERM_COMBO</span> in one time
       <span class="blocktermfill">BLOCK_TERM</span>. Assignments are highlighted according to the camper's preference:
       <span style="background:#1aff1a;">first</span>, <span style="background:#f0f000;">second</span>,
       <span style="background:#ffa500;">third</span>, <span style="background:#ff3333">fourth or worse</span>.
       Campers with no preferences for a <span class="chugfill">CHUG</span> group are highlighted in <span style="background:#ef60ff">purple</span>.
     </p>
+    <h4>How to Use:</h4>
     <ul>
-      <li>To change a camper's assignment, drag the camper's bubble from one
-        activity to another. When you are ready to save your manual changes, click
-        <b>Save</b>. To see a camper's preferred <span class="chugimfill">CHUGIM</span>, hover your mouse over
-        the bubble for that camper.
+      <li>
+        <strong>View Preferences:</strong> Hover your mouse over that camper's tile to display their <span class="chugfill">CHUG</span> preferences.
       </li>
-      <li>To re-run the assignment algorithm, click <b>Reassign</b>. This will
-        reassign campers automatically.</li>
-      <li>If a camper signed up late, or changed registration, they might not have
-        an assignment yet. Such campers will appear in a box
-        labeled <font color="red">Not Assigned Yet</font>. To assign these campers,
-        you can drag them to a <span class="chugfill">CHUG</span> and click Save, or click the Reassign button.</li>
-      <li>NOTE: campers who have not submitted preferences are NOT automatically assigned; they are highlighted in <span class="li_no_pref">purple</span>
-        and appear in the <font color="red">Not Assigned Yet</font> box.</li>
-      <li>To exit this page and return to the staff home page, click <b>Done</b>.
-      <li>To design custom schedules with each camper's saved <span class="chugfill">CHUG</span> assignments, click <b>Design Schedules</b>.
+      <li>
+        <strong>Change Assignments:</strong>
+        <ul>
+          <li> Drag a camper's bubble from one activity to another OR</li>
+          <li> Right-click on a camper's tile and select a new <span class="chugfill">CHUG</span>. </li>
+        </ul>
+      </li>
+      <li>
+        <strong>Reassign All Campers:</strong> Click <b>Reassign</b> to rerun the algorithm and assign all campers with preferences.
+      </li>
+    </ul>
+      <h4>Special Cases</h4>
+    <ul>
+      <li>
+        Campers who signed up late or changed registration may not have an assignment yet. Such campers will appear in a box labeled <font color="red">Not Assigned Yet</font>.
+        Assign these campers manually (drag and drop, or right-click on their tile), or click the <b>Reassign</b> to redo ALL assignments.
+      </li>
+      <li>
+        Campers without submitted preferences are NOT automatically assigned; they are highlighted in <span class="li_no_pref">purple</span>
+        and appear in the <font color="red">Not Assigned Yet</font> box.
+      </li>
+    </ul>
+      <h4>Additional Actions</h4>
+    <ul>
+      <li>
+        <strong>Save Changes:</strong> Adjustments are auto-saved after 3 seconds of inactivity
+      </li>
+      <li>
+        <strong>Design Schedules:</strong> Click <b>Design Schedules</b> to create custom schedules with each camper's saved <span class="chugfill">CHUG</span> assignments.
+      </li>
+      <li>
+        <strong>Exit:</strong> Select <b>Done</b> to exit this page and return to the staff home page.
+      </li>
     </ul>
   </div>
   <div class="toggler">

--- a/chugbot/meta/leveling.js
+++ b/chugbot/meta/leveling.js
@@ -70,8 +70,7 @@ function updateCount(chugId2Beta, curChugHolder) {
 	var chugHolders = $(groupHolder).children(".chugholder");
 	$(chugHolders).each(function (index) {
 		var chugId = $(this).attr('name');
-		var newCount = $(this).find("ul div").children().length;
-		console.log($(this));
+		var newCount = $(this).find("ul div li").length;
 		var min = parseInt(chugId2Beta[chugId]["min_size"]);
 		var max = parseInt(chugId2Beta[chugId]["max_size"]);
 		var colorClass = getColorForCount(newCount, min, max);
@@ -205,6 +204,139 @@ function doAssignmentAjax(action, title, errText,
 	});
 }
 
+// Updates the "chugim with free space" box at top of page
+// This function executes on page load and after a save (as capacity numbers change),
+// refreshing the box at those times
+function displayChugimWithSpace(edah_ids, group_ids, block) {
+	$.ajax({
+		url: 'levelingAjax.php',
+		type: 'post',
+		async: false,
+		data: {
+			matches_and_prefs: 1,
+			edah_ids: edah_ids,
+			group_ids: group_ids,
+			block_id: block
+		},
+		success: function (json) {
+			// general info
+			var groupId2Name = json["groupId2Name"];
+			var edahId2Name = json["edahId2Name"];
+			var chugId2Beta = json["chugId2Beta"];
+			var groupId2ChugId2MatchedCampers = json["groupId2ChugId2MatchedCampers"];
+			var chugId2FreeSpace = {};
+
+			// freeHtml is the HTML which will be output - a mega accordion containing another accordion
+			// which says how much space is left in chugim
+			var freeHtml = "<div class=\"accordion\" id=\"chugimMegaFreeSpaceAccordion\"><div class=\"accordion-item\"><h2 class=\"accordion-header\" id=\"chugimSpaceHeader\">"
+				+ "<button class=\"accordion-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseSpace\" aria-expanded=\"false\" aria-controls=\"collapseSpace\">"
+				+ capitalize(json['chugimTerm']) + " with Free Space</h4></button></h2><div id=\"collapseSpace\" class=\"accordion-collapse collapse\" aria-labelledby=\"chugimSpaceHeader\" data-bs-parent=\"#chugimMegaFreeSpaceAccordion\">"
+				+ "<div class=\"accordion-body\">";
+			freeHtml += "<h4>Expand to view " + json['chugimTerm'] + " with free space</h4>";
+
+			// add the accordion which will be for for each chug group
+			freeHtml += "<div class=\"accordion\" id=\"chugimFreeSpaceAccordion\">";
+	
+			// go through each chug group
+			var sortedGroupIds = sortedGroupIdKeysByName(groupId2ChugId2MatchedCampers, groupId2Name);
+			for (var j = 0; j < sortedGroupIds.length; j++) {
+				var groupId = sortedGroupIds[j];
+				var chugId2MatchedCampers = groupId2ChugId2MatchedCampers[groupId];
+				var sortedChugIds = chugIdsSortedByName(chugId2Beta, chugId2MatchedCampers);
+				freeHtml += "<div class=\"accordion-item\"><h2 class=\"accordion-header\" id=\"group_" + groupId + "\">"
+				+ "<button class=\"inner accordion-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseGroup_" + groupId + "\" aria-expanded=\"false\" aria-controls=\"collapseGroup_" + groupId + "\">"
+				+ groupId2Name[groupId] + "</h4></button></h2><div id=\"collapseGroup_" + groupId + "\" class=\"accordion-collapse collapse\" aria-labelledby=\"group_" + groupId + "\" data-bs-parent=\"#chugimFreeSpaceAccordion\">"
+				+ "<div class=\"accordion-body\">";
+				// see amount of space in each chug in the group
+				for (var i = 0; i < sortedChugIds.length; i++) {
+					var chugId = sortedChugIds[i];
+					if (chugId == -1) {
+						continue
+					}
+					var matchedCampers = chugId2MatchedCampers[chugId];
+					var curCount = matchedCampers.length;
+					// Add a chug holder, and put camper holders inside it.
+					var freeSpace;
+					var name = chugId2Beta[chugId]["name"];
+					var chugMin = chugId2Beta[chugId]["min_size"];
+					var chugMax = chugId2Beta[chugId]["max_size"];
+					if (chugMax == "0" || chugMax == 0 || chugMax == "10000" || chugMax == 10000 || 
+						chugMax === null || (typeof (chugMax) === 'undefined')) {
+						freeSpace = "unlimited";
+					} else if ((!(chugId in chugId2FreeSpace)) && chugMax > curCount) {
+						freeSpace = chugMax - curCount;
+					}
+
+					// assembles the line in following format:
+					//  "CHUG NAME: x space(s) left"
+					var sp = "spaces";
+					var endTag = " left<br>";
+					if (freeSpace == 1) {
+						sp = "space";
+					} else if (freeSpace == "unlimited") {
+						sp = "space";
+						endTag = "<br>";
+					}
+					var sp = (freeSpace == 1 || freeSpace == "unlimited") ? "space" : "spaces";
+					freeHtml += name + ": " + freeSpace + " " + sp + endTag;
+
+				}
+				freeHtml += "</div></div></div>"
+			}
+			// Display chugim with space.  Link to the reporting page.
+			var loc = window.location;
+			var basePath = removeLastDirectoryPartOf(loc.pathname);
+			var edahQueryString = "";
+			$.each(edahId2Name, function (edahId, edahName) {
+				edahQueryString += "&edah_ids%5B%5D=" + edahId;
+			});
+			var groupQueryString = "";
+			$.each(groupId2Name, function (groupId, groupName) {
+				groupQueryString += "&group_ids%5B%5D=" + groupId;
+			});
+			
+			var reportLink = "<a class=\"btn btn-dark text-light mt-2\" role=\"button\" href=\"" + loc.protocol + "//" + loc.hostname + ":" + loc.port + basePath + "/report.php?report_method=7&do_report=1&block_ids%5B%5D=" + block + edahQueryString + groupQueryString + "&submit=Display\">Free Space Report</a>";
+			freeHtml += reportLink + "</div></div></div></div>";
+			$("#results").html(freeHtml);
+			$("#results:visible").removeAttr("style").fadeOut();
+			$("#results").show("slide", 500);
+			$("#results").attr('disabled', false);
+		},
+		error: function (xhr, desc, err) {
+			console.log(xhr);
+			console.log("Details: " + desc + "\nError:" + err);
+		}});
+}
+
+// Helper function to display a Bootstap "toast" message - alert popup in lower-right corner
+// Used for autosave functionality
+function showToast(type, title, message) {
+    const toastId = `toast-${Date.now()}`;
+    const toastHTML = `
+        <div id="${toastId}" class="toast align-items-center bg-${type}-subtle border-0 m-3" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="5000">
+            <div class="d-flex">
+                <div class="toast-body">
+                    <strong>${title}</strong><br>${message}
+                </div>
+                <button type="button" class="btn-close btn-close-dark me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>`;
+    
+    // Append the toast to the container
+    const toastContainer = document.getElementById("toast-container");
+    toastContainer.insertAdjacentHTML("beforeend", toastHTML);
+
+    // Initialize and show the toast
+    const toastElement = document.getElementById(toastId);
+    const bootstrapToast = new bootstrap.Toast(toastElement);
+    bootstrapToast.show();
+
+    // Remove the toast after it hides
+    toastElement.addEventListener("hidden.bs.toast", () => {
+        toastElement.remove();
+    });
+}
+
 // Get the current match and chug info for this edah/block, and display it by group.
 // Also, display chugim with no matches, because the user needs the ability to drag
 // to them.
@@ -256,6 +388,7 @@ function getAndDisplayCurrentMatches() {
 				showEdahForCamper = 1;
 			}
 			groupId2ChugId2MatchedCampers = json["groupId2ChugId2MatchedCampers"];
+			groupId2EdahId2AllowedChugim = json["groupId2EdahId2AllowedChugim"];
 			camperId2Group2PrefList = json["camperId2Group2PrefList"];
 			existingMatches = json["existingMatches"];
 			deDupMatrix = json["deDupMatrix"];
@@ -278,6 +411,7 @@ function getAndDisplayCurrentMatches() {
 				// Within each group, add a holder for campers, and then populate with
 				// campers.  List chugim in alphabetical order.
 				var sortedChugIds = chugIdsSortedByName(chugId2Beta, chugId2MatchedCampers);
+				var notAssignedHtml = "";
 				for (var i = 0; i < sortedChugIds.length; i++) {
 					var chugId = sortedChugIds[i];
 					var matchedCampers = chugId2MatchedCampers[chugId];
@@ -307,15 +441,15 @@ function getAndDisplayCurrentMatches() {
 						chugId2FreeSpace[chugId] = chugMax - curCount;
 					}
 					var colorClass = getColorForCount(curCount, chugMin, chugMax);
-					html += "<div id=\"chugholder_" + chugId + "\" name=\"" + chugId + "\" class=\"ui-widget ui-helper-clearfix chugholder card-body bg-white border rounded mb-3 pb-0 ui-droppable\">\n";
+					htmlChug = "<div id=\"chugholder_" + chugId + "\" name=\"" + chugId + "\" class=\"ui-widget ui-helper-clearfix chugholder card-body bg-white border rounded mb-3 pb-0 ui-droppable\">\n";
 					if (chugName == "Not Assigned Yet") {
-						html += "<h4><font color=\"red\">" + chugName + "</font></h4>";
+						htmlChug += "<h4><font color=\"red\">" + chugName + "</font></h4>";
 					} else {
-						html += "<h4>" + "<a href=\"" + editChugUrl + "\">" + chugName + "</a>"
+						htmlChug += "<h4>" + "<a href=\"" + editChugUrl + "\">" + chugName + "</a>"
 							+ " (min = " + chugMin + ", max = " + chugMax + ", <span name=\"curCountHolder\" class=\"" + colorClass + "\" value=\"" + curCount + "\">cur = " + curCount + "</span>)</h4>";
 					}
-					html += "<ul class=\"gallery ui-helper-reset ui-helper-clearfix\">";
-					html += "<div class=\"row row-cols-1 row-cols-md-2 justify-content-center mt-2\">"
+					htmlChug += "<ul class=\"gallery ui-helper-reset ui-helper-clearfix\">";
+					htmlChug += "<div class=\"row row-cols-1 row-cols-md-2 justify-content-center mt-2\">"
 					$.each(matchedCampers,
 						function (index, camperId) {
 							var camperName = camperId2Name[camperId];
@@ -323,7 +457,7 @@ function getAndDisplayCurrentMatches() {
 							var camperEdah = edahId2Name[edahId];
 							var camperEdahText = "";
 							if (Object.keys(edahId2Name).length > 1) {
-								camperEdahText = "<div class=\"card-body ps-1 pe-1 mb-0 d-flex align-items-center\" style=\"font-size:70%\"><p class=\"m-0\">(" + camperEdah + ")</p></div>";
+								camperEdahText = "<p class=\"card-body ps-1 pe-1 mb-0 d-flex align-items-center m-0\" style=\"font-size:70%\">(" + camperEdah + ")</p>";
 							}
 							var prefListText = "";
 							var prefClass = prefClasses[prefClasses.length - 1];
@@ -332,12 +466,11 @@ function getAndDisplayCurrentMatches() {
 								if (groupId in group2PrefList) {
 									var prefList = group2PrefList[groupId];
 									$.each(prefList, function (index, prefChugId) {
-										var listNum = index + 1;
 										if (prefListText == "") {
-											prefListText += "Preferences:\n";
+											prefListText += "Preferences:<ol>";
 										}
 										if (prefChugId in chugId2Beta) {
-											prefListText += listNum + ". " + chugId2Beta[prefChugId]["name"] + "\n";
+											prefListText += "<li>" + chugId2Beta[prefChugId]["name"] + "</li>";
 										}
 										if (prefChugId == chugId) {
 											if (index < prefClasses.length) {
@@ -347,6 +480,7 @@ function getAndDisplayCurrentMatches() {
 											}
 										}
 									});
+									prefListText += "</ol>"
 								}
 								else {
 									prefClass = "li_no_pref";
@@ -355,66 +489,173 @@ function getAndDisplayCurrentMatches() {
 							else {
 								prefClass = "li_no_pref";
 							}
-							var titleText = "title=\"<no preferences>\"";
+							var titleText = "title=\"No preferences\"";
 							if (prefListText) {
 								// If we have a pref list, write it as a tool tip.
 								titleText = "title=\"" + prefListText + "\"";
 							}
-							html += "<li value=\"" + camperId + "\" class=\" " + prefClass + " card p-0\" " + titleText;
-							html += "><h5 class=\"card-header text-break p-1 mb-0 d-flex align-items-center justify-content-center h-100\">" + camperName + "</h5>"+ camperEdahText + "<div class=\"dup-warning\"></div></li>\n";
+							htmlChug += "<li value=\"" + camperId + "\" data-bs-toggle=\"tooltip\" data-bs-html=\"true\" data-bs-placement=\"bottom\" class=\" " + prefClass + " card p-0\" " + titleText;
+							htmlChug += "><h5 class=\"card-header text-break p-1 mb-0 d-flex align-items-center justify-content-center h-100\">" + camperName + "</h5>"+ camperEdahText + "<div class=\"dup-warning\"></div></li>\n";
 						});
-					html += "</div></ul><br style=\"clear: both\"></div>\n";
+					htmlChug += "</div></ul><br style=\"clear: both\"></div>\n";
+					if (chugId != -1) {
+						html += htmlChug;
+					}
+					else {
+						notAssignedHtml = htmlChug;
+					}
 				}
+				html += notAssignedHtml;
 				html += "</div>\n";
 			};
-			// Compute and display chugim with space.  Link to the reporting page.
-			var loc = window.location;
-			var basePath = removeLastDirectoryPartOf(loc.pathname);
-			var edahQueryString = "";
-			$.each(edahId2Name, function (edahId, edahName) {
-				edahQueryString += "&edah_ids%5B%5D=" + edahId;
-			});
-			var groupQueryString = "";
-			$.each(groupId2Name, function (groupId, groupName) {
-				groupQueryString += "&group_ids%5B%5D=" + groupId;
-			});
-			var freeHtml = "<div class=\"accordion\" id=\"chugimFreeSpaceAccordion\"><div class=\"accordion-item\"><h2 class=\"accordion-header\" id=\"chugimSpaceHeader\">"
-				+ "<button class=\"accordion-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseSpace\" aria-expanded=\"false\" aria-controls=\"collapseSpace\">"
-				+ capitalize(json['chugimTerm']) + " with Free Space</h4></button></h2><div id=\"collapseSpace\" class=\"accordion-collapse collapse\" aria-labelledby=\"chugimSpaceHeader\" data-bs-parent=\"#chugimFreeSpaceAccordion\">"
-				+ "<div class=\"accordion-body\">";
-						
-				//+ "</div></div></div></div>";
-			var reportLink = "<a class=\"btn btn-dark text-light mt-2\" role=\"button\" href=\"" + loc.protocol + "//" + loc.hostname + ":" + loc.port + basePath + "/report.php?report_method=7&do_report=1&block_ids%5B%5D=" + block + edahQueryString + groupQueryString + "&submit=Display\">Report</a>";
-			freeHtml += "<h4>" + capitalize(json['chugimTerm']) + " with Free Space:</h4>";
-			var sortedChugIds = chugIdsSortedByName(chugId2Beta, chugId2Beta);
-			for (var i = 0; i < sortedChugIds.length; i++) {
-				var betaHash = chugId2Beta[sortedChugIds[i]];
-				var name = betaHash["name"];
-				var groupName = betaHash["group_name"];
-				var freeSpace = undefined;
-				if (sortedChugIds[i] in chugId2FreeSpace) {
-					freeSpace = chugId2FreeSpace[sortedChugIds[i]];
-				}
-				if (freeSpace !== undefined) {
-					var sp = "spaces";
-					var endTag = " left<br>";
-					if (freeSpace == 1) {
-						sp = "space";
-					} else if (freeSpace == "unlimited") {
-						sp = "space";
-						endTag = "<br>";
-					}
-					var sp = (freeSpace == 1 || freeSpace == "unlimited") ? "space" : "spaces";
-					freeHtml += name + " (" + groupName + "): " + freeSpace + " " + sp + endTag;
-				}
-			}
-			freeHtml += reportLink + "</div></div></div></div>";
-			$("#results").html(freeHtml);
-			$("#results:visible").removeAttr("style").fadeOut();
-			$("#results").show("slide", 500);
-			$("#results").attr('disabled', false);
+
+			// Display chugim with space
+			displayChugimWithSpace(edah_ids, group_ids, block);
+			
 			// Display matches and chugim.
 			$("#fillmatches").html(html);
+
+			// enable tooltips
+			var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+			var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+				return new bootstrap.Tooltip(tooltipTriggerEl)
+			})
+
+			// Variables for context menu (right-click on camper tiles)
+			const contextMenu = $("#context-menu");
+			const contextMenuOptions = $("#context-menu-options");
+			var targetElement = null; // target for when element is right-clicked on
+		
+			// Right-click event on camper tiles
+			$(document).on("contextmenu", ".gallery li", function (event) {
+				event.preventDefault();
+		
+				// Get variables
+				camperId = $(this).attr("value");
+				groupId = $(this).closest(".groupholder").attr("name");
+				edahId = camperId2Edah[camperId];
+				curChugId = $(this).closest(".chugholder").attr("name");
+		
+				contextMenuOptions.empty(); // Clear previous options
+		
+				// Fetch available chugim for this group
+				let availableChugim = groupId2EdahId2AllowedChugim[groupId][edahId];
+		
+				// Set available chugim
+				availableChugim.forEach(function (chugId) {
+					if (chugId == curChugId) {
+						return;
+					}
+					let chugName = chugId2Beta[chugId]["name"];
+					let menuItem = $("<li>").text(chugName).attr("data-chug-id", chugId).attr("camper-id", camperId);
+					contextMenuOptions.append(menuItem);
+				});
+
+				// Unassign option (and make it red!)
+				let chugName = "Unassign Camper";
+				let menuItem = $("<li style=\"color: red\">").text(chugName).attr("data-chug-id", -1).attr("camper-id", camperId);
+				contextMenuOptions.append(menuItem);
+
+				// Save the target element (so we can remove it from the list it is currently in and 
+				// add it to the new one - change chug assignment)
+				targetElement = event.target.parentElement;
+				if (targetElement.nodeName == "DIV") {
+					targetElement = targetElement.parentElement;
+				}
+
+				// ChugId it comes from
+				var sourceChugId = $(targetElement).closest(".chugholder").attr("name");
+				$(this).data("sourceChugId", sourceChugId);
+		
+				// Position menu
+				contextMenu.css({ top: event.pageY + "px", left: event.pageX + "px" }).show();
+			});
+		
+			// Handle chug selection
+			$(document).on("click", "#context-menu-options li", function () {
+				// Uses very similar code from when elements are dropped, except some data (e.g. ids, elements)
+				// is from different sources. There is just enough different (plus the challenge of either simulating
+				// a dropped element, or creating and calling a function with 8 parameters) it felt better to 
+				// just re-use the code here
+				let newChugId = $(this).attr("data-chug-id");
+				let camperId = $(this).attr("camper-id");
+		
+				var droppedOn = document.getElementById("chugholder_"+newChugId).getElementsByClassName('row')[0];
+				var droppedChugId = newChugId;
+				var dropped = targetElement;
+				// Change the color of the dropped item according to the camper's
+				// preference for the dropped-on chug.
+				var groupId = $(dropped).parent().parent().parent().parent().attr("name");
+				var chugId2MatchedCampers = groupId2ChugId2MatchedCampers[groupId];
+				var prefClass = prefClasses[prefClasses.length - 1];
+				if (camperId in camperId2Group2PrefList) {
+					var group2PrefList = camperId2Group2PrefList[camperId];
+					if (groupId in group2PrefList) {
+						var prefList = group2PrefList[groupId];
+						$.each(prefList, function (index, prefChugId) {
+							if (prefChugId == droppedChugId) {
+								var idx = (index < prefClasses.length) ? index : prefClasses.length - 1;
+								prefClass = prefClasses[idx];
+								return false; // break
+							}
+						});
+					}
+					else {
+						prefClass = "li_no_pref";
+					}
+				}
+				else {
+					prefClass = "li_no_pref";
+				}
+				if (prefClass) {
+					$.each(prefClasses, function (index, prefClassToRemove) {
+						// Remove old color class.
+						$(dropped).removeClass(prefClassToRemove);
+					});
+					// Add new color class.
+					$(dropped).addClass(prefClass);
+				}
+				$(dropped).detach().css({ top: 0, left: 0 }).appendTo(droppedOn);
+				// Check to see if the dropped-on chug is a duplicate for the dropped
+				// camper, and if so, show a warning.
+				var dupWarningDiv = $(dropped).find(".dup-warning");
+				$(dupWarningDiv).hide(); // Hide dup warning by default.
+				// Store sourceChugId in a variable, and remove it from the element.
+				var sourceChugId = $(dropped).data("sourceChugId");
+				$(dropped).removeData("sourceChugId");
+				if (camperId in existingMatches) {
+					var matchHash = existingMatches[camperId];
+					// Update matchHash: we need to remove the chug from which the camper
+					// was dragged, and add the one in which they were dropped.  We won't
+					// count the one in which they were dropped when we check for dups.
+					delete matchHash[sourceChugId];
+					var ourBlockName = $(".blockfill").text().substring(12);
+					matchHash[droppedChugId] = ourBlockName;
+					var dupId = isDupOf(droppedChugId, matchHash,
+						deDupMatrix, chugId2MatchedCampers,
+						$(dropped).attr('value'));
+					if (dupId in chugId2Beta && dupId != -1) {
+						var dupName = chugId2Beta[dupId]["name"];
+						var dupGroup = chugId2Beta[dupId]["group_name"];
+						var dupBlockName = matchHash[dupId];
+						$(dupWarningDiv).html("<div class=\"card bg-warning border-danger border-3 m-2 mt-0\" style=\"font-size: 70%\">Dup of " + dupName + " (" + dupBlockName + " " + dupGroup + ")</div>");
+						$(dupWarningDiv).fadeIn("fast");
+					}
+				}
+				// Update counts.
+				updateCount(chugId2Beta, droppedOn);
+				autosave();
+		
+				// Reset
+				targetElement = null;
+				contextMenu.hide();
+			});
+		
+			// Hide context menu when clicking elsewhere
+			$(document).click(function () {
+				targetElement = null;
+				contextMenu.hide();
+			});
 		},
 		error: function (xhr, desc, err) {
 			console.log(xhr);
@@ -526,16 +767,17 @@ function getAndDisplayCurrentMatches() {
 							var dupId = isDupOf(droppedChugId, matchHash,
 								deDupMatrix, chugId2MatchedCampers,
 								$(dropped).attr('value'));
-							if (dupId in chugId2Beta) {
+							if (dupId in chugId2Beta && dupId != -1) {
 								var dupName = chugId2Beta[dupId]["name"];
 								var dupGroup = chugId2Beta[dupId]["group_name"];
 								var dupBlockName = matchHash[dupId];
-								$(dupWarningDiv).html("<small><span class=\"label label-warning\">Dup of " + dupName + " (" + dupBlockName + " " + dupGroup + ")</span></small>");
+								$(dupWarningDiv).html("<div class=\"card bg-warning border-danger border-3 m-2 mt-0\" style=\"font-size: 70%\">Dup of " + dupName + " (" + dupBlockName + " " + dupGroup + ")</div>");
 								$(dupWarningDiv).fadeIn("fast");
 							}
 						}
 						// Update counts.
 						updateCount(chugId2Beta, droppedOn);
+						autosave();
 					}
 				});
 			});
@@ -590,7 +832,6 @@ $(function () {
 				}
 			});
 			$(".edahtermbothfill").text(function () {
-				console.log(json)
 				if (json.edahBothTerm &&
 					json.edahBothTerm.length > 0) {
 					return $(this).text().replace("EDAH_TERM_COMBO", json.edahBothTerm);
@@ -683,48 +924,69 @@ $(function () {
 		if (r != true) {
 			return;
 		}
-		// Loop through the groups, and then loop through the
-		// chugim within each group.
-		var assignments = new Object(); // Associative array
-		var groupDivs = $(document).find(".groupholder");
-		for (var i = 0; i < groupDivs.length; i++) {
-			var groupElement = groupDivs[i];
-			var groupId = groupElement.getAttribute("name");
-			var chugDivs = $(groupElement).find(".chugholder");
-			assignments[groupId] = new Object();// Associative array
-			for (var j = 0; j < chugDivs.length; j++) {
-				var chugDiv = chugDivs[j];
-				var chugId = chugDiv.getAttribute("name");
-				var ulElement = $(chugDiv).find("ul");
-				var camperElements = $(ulElement).find("li");
-				assignments[groupId][chugId] = [];
-				for (var k = 0; k < camperElements.length; k++) {
-					var camperElement = camperElements[k];
-					var camperId = camperElement.getAttribute("value");
-					assignments[groupId][chugId].push(camperId);
-				}
-			}
-		}
-		var values = {};
-		values["save_changes"] = 1;
-		values["assignments"] = assignments;
-		values["edah_ids"] = edah_ids;
-		values["group_ids"] = group_ids;
-		values["block"] = block;
-		$.ajax({
-			url: 'levelingAjax.php',
-			type: 'post',
-			async: false,
-			data: values,
-			success: function (json) {
-				doAssignmentAjax("get_current_stats", "Changes Saved! Stats:", "save your changes",
-					edah_ids, group_ids, block);
-				getAndDisplayCurrentMatches();
-			},
-			error: function (xhr, desc, err) {
-				console.log(xhr);
-				console.log("Details: " + desc + "\nError:" + err);
-			}
-		});
+		save(edah_ids, group_ids, block);
 	});
 });
+
+
+// Prepare autosaver
+let saveTimer;
+function autosave() {
+    clearTimeout(saveTimer); // Clear any pending save calls
+    saveTimer = setTimeout(() => {
+		const edah_ids = getParameterByName("edah_ids");
+		const group_ids = getParameterByName("group_ids");
+		const block = getParameterByName("block");
+        save(edah_ids, group_ids, block);
+    }, 3000); // Adjust the delay (in milliseconds) as needed
+}
+
+// Save function
+async function save(edah_ids, group_ids, block) {
+	showToast("info", "Loading", "Please wait, save in progress...");
+	await new Promise(resolve => setTimeout(resolve, 100));
+	// Loop through the groups, and then loop through the
+	// chugim within each group.
+	// + adds short delay so browser renders "loading" message
+	var assignments = new Object(); // Associative array
+	var groupDivs = $(document).find(".groupholder");
+	for (var i = 0; i < groupDivs.length; i++) {
+		var groupElement = groupDivs[i];
+		var groupId = groupElement.getAttribute("name");
+		var chugDivs = $(groupElement).find(".chugholder");
+		assignments[groupId] = new Object();// Associative array
+		for (var j = 0; j < chugDivs.length; j++) {
+			var chugDiv = chugDivs[j];
+			var chugId = chugDiv.getAttribute("name");
+			var ulElement = $(chugDiv).find("ul");
+			var camperElements = $(ulElement).find("li");
+			assignments[groupId][chugId] = [];
+			for (var k = 0; k < camperElements.length; k++) {
+				var camperElement = camperElements[k];
+				var camperId = camperElement.getAttribute("value");
+				assignments[groupId][chugId].push(camperId);
+			}
+		}
+	}
+	var values = {};
+	values["save_changes"] = 1;
+	values["assignments"] = assignments;
+	values["edah_ids"] = edah_ids;
+	values["group_ids"] = group_ids;
+	values["block"] = block;
+	try {
+		const response = await $.ajax({
+			url: 'levelingAjax.php',
+			type: 'post',
+			data: values
+		});
+		doAssignmentAjax("get_current_stats", "Changes Saved! Stats:", "save your changes",
+			edah_ids, group_ids, block);
+		displayChugimWithSpace(edah_ids, group_ids, block);
+		showToast("success", "Success", "Updated " + response.chugimTerm + " were successfully saved.");
+	} catch (error) {
+		console.log(error);
+		console.log("Details: " + error.statusText + "\nError: " + error.responseJSON.error);
+		showToast("danger", "Error", "Something went wrong while saving your changes. Please try again.");
+	}
+}

--- a/chugbot/meta/leveling.js
+++ b/chugbot/meta/leveling.js
@@ -560,6 +560,15 @@ function getAndDisplayCurrentMatches() {
 				// add it to the new one - change chug assignment)
 				targetElement = event.target.parentElement;
 				if (targetElement.nodeName == "DIV") {
+					// If the specific element being clicked on was a DIV (as opposed to H5 or P), we know it was the dup-warning for a camper
+					// Instead, we want to move up a level to maintain consistency with the H5 and P elements which could be clicked on
+					// Hierarchy:
+					/* 	<li>
+					 *		<h5>
+					 *		<p>
+					 *		<div DUP> - usually empty, holds dup warning if present
+					 *			<div CARD> - written when there is a dup warning - able to be clicked on
+					 */
 					targetElement = targetElement.parentElement;
 				}
 

--- a/chugbot/meta/view.css
+++ b/chugbot/meta/view.css
@@ -26,7 +26,7 @@ form li {
     margin-top: 20px;
     background:#fff;
     text-align: center;
-    width:35%;
+    width:40%;
     border-radius: 10px;
     -moz-border-radius: 10px;
     -webkit-border-radius: 10px;

--- a/chugbot/printSchedules.php
+++ b/chugbot/printSchedules.php
@@ -141,17 +141,17 @@
         // Now, replace all keywords with the info from the camper's row
 
         // 1. Manual ones we know to always expect (name, bunk, edah, rosh, roshphone)
-        $schedule = str_replace("{{Name}}", $row[0], $schedule); // name
-        $schedule = str_replace("{{Bunk}}", $row[1], $schedule); // bunk
+        $schedule = str_replace("{{Name}}", $row[0] ?? "", $schedule); // name
+        $schedule = str_replace("{{Bunk}}", $row[1] ?? "", $schedule); // bunk
         $schedule = str_replace("{{" . ucfirst(edah_term_singular) . "}}", $row[2], $schedule); // edah
-        $schedule = str_replace("{{Rosh}}", $row[3], $schedule); // rosh
-        $schedule = str_replace("{{Rosh Phone Number}}", $row[4], $schedule); // roshphone
+        $schedule = str_replace("{{Rosh}}", $row[3] ?? "", $schedule); // rosh
+        $schedule = str_replace("{{Rosh Phone Number}}", $row[4] ?? "", $schedule); // roshphone
 
         // 2. Replace Chug/Perek Assignments
         for($i = 0; $i < count($chugGroups); $i++) {
             // $chugGroups has chug group names corresponding to the order the chugim are ordered in the 
             // SQL response, so can iterate through those lists simultaneously (and 5 fields are always expected)
-            $schedule = str_replace("{{" . $chugGroups[$i] . "}}", $row[$i+5], $schedule);
+            $schedule = str_replace("{{" . $chugGroups[$i] . "}}", $row[$i+5] ?? "", $schedule);
         }
 
         $schedule .= "</div>"; // close the div (or else we end up with them all nested!)

--- a/chugbot/rankCamperChoices.html
+++ b/chugbot/rankCamperChoices.html
@@ -11,8 +11,7 @@
   <script src="meta/ajax.js"></script>
   <link rel="stylesheet" href="meta/view.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js" integrity="sha256-AAhU14J4Gv8bFupUUcHaPQfvrdNauRHMt+S4UVcaJb0=" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" 
-    integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" 
     integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous"></head>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">

--- a/chugbot/report.php
+++ b/chugbot/report.php
@@ -106,7 +106,11 @@ class PDF extends FPDF
         }
 
         $wmax = ($w - 2 * $this->cMargin) * 1000 / $this->FontSize;
-        $s = str_replace("\r", '', $txt);
+        if (!empty($txt)) {
+            $s = str_replace("\r", '', $txt);
+        } else {
+            $s = "";
+        }
         $nb = strlen($s);
         if ($nb > 0 and $s[$nb - 1] == "\n") {
             $nb--;
@@ -477,15 +481,6 @@ class ZebraReport
                     }
                 }
                 array_push($pdfDataRow, $d);
-                //if ((strlen($d) * $this->mult) > $pdfColWidths[$i]) {
-                //$pdfColWidths[$i] = (strlen($d) * $this->mult);
-                //}
-                $words = explode(" ", $d);
-                foreach ($words as $word) {
-                    if ((strlen($word) * $this->mult) + $this->add > $pdfColWidths[$i]) {
-                        $pdfColWidths[$i] = (strlen($word) * $this->mult) + $this->add;
-                    }
-                }
                 $i++;
             }
 


### PR DESCRIPTION
# Updates
## PHP 8.3
Updates codebase to work with PHP 8.3 (from 8.0) after upgrading active instances. Also enables certificate for LA Day Camp

## Leveling Page
Three main improvements are made to the page where an admin manually adjusts chug assignments after the assignment algorithm runs:
1. Displays message after successfully saving new chugim
     - Bootstrap Toast appears in bottom right indicating success
     - Another is used when the save begins to show progress
2. Autosave functionality enabled
     - A timer is started as each change is made; after 3 seconds of no new changes, any updates are saved
3. Ability to assign campers without drag and drop
     - A new menu appears after right clicking on a camper tile to select a new chug for the camper

In addition, a few other minor fixes/updates were made:
 - Issue with all .html pages where dropdowns are nonresponsive -- FIXED
 - Chug counts on leveling page randomly showed the number of assigned campers as double -- FIXED
 - Duplicate warnings not showing -- FIXED
 - Improvements with handling campers not assigned a chug
 - Cosmetic improvements to chugim with free space holder
 - Uses Bootstrap Tooltips to show camper preferences when hovering over their icon

# Testing instructions
Generally just experiment by interacting with the leveling page in different ways. To view duplicate warnings, I did the following:
1. Use Shorashim + Anafim, all chug groups, Session A
2. Update "Beach Jewelry" chug to dedup with the following:
     - Chetz V'Keshet (Archery) (Chug Bet)
     - Bishul Im Ivrit (Cooking with Hebrew) (Chug Dalet)
     - Beach Jewelry (Chug Aleph)
     - Beach Jewelry (Chug Bet)
     - Beach Jewelry (Chug Gimel)
     - Beach Jewelry (Chug Dalet)
     - Beachy Keen Wearables and Souvenirs (Chug Aleph)
     - Beachy Keen Wearables and Souvenirs (Chug Bet)
     - Beachy Keen Wearables and Souvenirs (Chug Gimel)
     - Beachy Keen Wearables and Souvenirs (Chug Dalet)
     - Cardboard Engineering (Makerspace) (Chug Aleph)
     - Chetz V'Keshet - Archery (Chug Bet)
4. Update "Cardboard Engineering (Makerspace)" chug to dedup with the following:
     - Chetz V'Keshet (Archery) (Chug Bet)
     - Beach Jewelry (Chug Aleph)
     - Beach Jewelry (Chug Bet)
     - Beach Jewelry (Chug Gimel)
     - Beach Jewelry (Chug Dalet)
     - Cardboard Engineering (Makerspace) (Chug Aleph)
     - Chetz V'Keshet - Archery (Chug Bet)
     - Handasah (Engineering & Makerspace) (Chug Aleph)
5. Reassigning James Rhodes, Natasha Romanoff, and some of the Weasleys between the two should generate a warning. Note that if a camper was saved to a particular chug previously that is set to dedup, the warning does not appear (hence why returning to the previous chug removes the warning)