### PR TITLE
sort_order Extension & Reset Password Security

### DIFF
--- a/ChugBotWithTestDBData.sql
+++ b/ChugBotWithTestDBData.sql
@@ -185,6 +185,7 @@ CREATE TABLE `blocks` (
   `block_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
   `visible_to_campers` tinyint(1) NOT NULL DEFAULT '0',
+  `sort_order` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`block_id`),
   UNIQUE KEY `uk_blocks` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
@@ -196,7 +197,7 @@ CREATE TABLE `blocks` (
 
 LOCK TABLES `blocks` WRITE;
 /*!40000 ALTER TABLE `blocks` DISABLE KEYS */;
-INSERT INTO `blocks` VALUES (1,'Session A',0),(2,'Session B',1),(3,'Session C',1),(4,'Session D',1);
+INSERT INTO `blocks` VALUES (1,'Session A',0,1),(2,'Session B',1,2),(3,'Session C',1,3),(4,'Session D',1,4);
 /*!40000 ALTER TABLE `blocks` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -354,6 +355,7 @@ CREATE TABLE `chug_groups` (
   `group_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
   `active_block_id` int,
+  `sort_order` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`group_id`),
   UNIQUE KEY `uk_groups` (`name`),
   CONSTRAINT `chug_groups_ibfk_1` FOREIGN KEY (`active_block_id`) REFERENCES `blocks` (`block_id`) ON DELETE SET NULL ON UPDATE CASCADE
@@ -366,7 +368,7 @@ CREATE TABLE `chug_groups` (
 
 LOCK TABLES `chug_groups` WRITE;
 /*!40000 ALTER TABLE `chug_groups` DISABLE KEYS */;
-INSERT INTO `chug_groups` VALUES (1,'Chug Aleph',1),(2,'Chug Bet',1),(4,'Chug Dalet',1),(3,'Chug Gimel',1);
+INSERT INTO `chug_groups` VALUES (1,'Chug Aleph',1,1),(2,'Chug Bet',1,2),(4,'Chug Dalet',1,4),(3,'Chug Gimel',1,3);
 /*!40000 ALTER TABLE `chug_groups` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -708,6 +710,7 @@ DROP TABLE IF EXISTS `sessions`;
 CREATE TABLE `sessions` (
   `session_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `sort_order` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`session_id`),
   UNIQUE KEY `uk_sessions` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
@@ -719,7 +722,7 @@ CREATE TABLE `sessions` (
 
 LOCK TABLES `sessions` WRITE;
 /*!40000 ALTER TABLE `sessions` DISABLE KEYS */;
-INSERT INTO `sessions` VALUES (16,'Full Summer'),(5,'Session A'),(6,'Session B'),(7,'Session C'),(8,'Session D'),(9,'Sessions AB'),(12,'Sessions ABC'),(14,'Sessions ABD'),(10,'Sessions AC'),(15,'Sessions ACD'),(11,'Sessions AD'),(17,'Sessions BC'),(18,'Sessions BCD'),(20,'Sessions CD');
+INSERT INTO `sessions` VALUES (16,'Full Summer',1),(5,'Session A',2),(6,'Session B',3),(7,'Session C',4),(8,'Session D',5),(9,'Sessions AB',6),(12,'Sessions ABC',7),(14,'Sessions ABD',8),(10,'Sessions AC',9),(15,'Sessions ACD',10),(11,'Sessions AD',11),(17,'Sessions BC',12),(18,'Sessions BCD',13),(20,'Sessions CD',14);
 /*!40000 ALTER TABLE `sessions` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/Docker/ChugBotWithDataProdVers.sql
+++ b/Docker/ChugBotWithDataProdVers.sql
@@ -153,6 +153,7 @@ CREATE TABLE `blocks` (
   `block_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `visible_to_campers` tinyint(1) NOT NULL DEFAULT '0',
+  `sort_order` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`block_id`),
   UNIQUE KEY `uk_blocks` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
@@ -337,6 +338,7 @@ CREATE TABLE `chug_groups` (
   `group_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `active_block_id` int,
+  `sort_order` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`group_id`),
   UNIQUE KEY `uk_groups` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
@@ -668,6 +670,7 @@ DROP TABLE IF EXISTS `sessions`;
 CREATE TABLE `sessions` (
   `session_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
+  `sort_order` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`session_id`),
   UNIQUE KEY `uk_sessions` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;

--- a/chugbot/PHPMailer/PHPMailer.php
+++ b/chugbot/PHPMailer/PHPMailer.php
@@ -1281,7 +1281,9 @@ class PHPMailer
     public function setFrom($address, $name = '', $auto = true)
     {
         $address = trim($address);
-        $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
+        if(!empty($name)) {
+            $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
+        }
         //Don't validate now addresses with IDN. Will be done in send().
         $pos = strrpos($address, '@');
         if (

--- a/chugbot/addEdah.php
+++ b/chugbot/addEdah.php
@@ -46,11 +46,4 @@ $commentsField->setInputValue($addEdahPage->columnValue("comments"));
 $commentsField->setGuideText("Comments about this " . ucfirst(edah_term_singular) . " (optional)");
 $addEdahPage->addFormItem($commentsField);
 
-$sortOrderField = new FormItemSingleTextField("Sort Order", false, "sort_order", 4);
-$sortOrderField->setInputType("number");
-$sortOrderField->setInputMaxLength(3);
-$sortOrderField->setInputValue($addEdahPage->columnValue("sort_order"));
-$sortOrderField->setGuideText("Indicate where this " . (edah_term_singular) . " should appear when all " . (edah_term_plural) . " are sorted, with lower appearing earlier.  For example, if this is the youngest and that group should be listed first, enter 1.  If this group should appear third, enter 3.  If no choices are made for this box, edot will be listed alphabetically.");
-$addEdahPage->addFormItem($sortOrderField);
-
 $addEdahPage->renderForm();

--- a/chugbot/ajax.php
+++ b/chugbot/ajax.php
@@ -54,8 +54,10 @@ if (isset($_POST["get_legal_id_to_name"])) {
     // Return a list of legal IDs.  We assume that the query maps
     // legal IDs to their corresponding names.
     $retVal = array();
+    $i = 0;
     while ($row = $result->fetch_row()) {
-        $retVal[$row[0]] = $row[1];
+        $retVal += [$i => ["name" => $row[1], "id" => $row[0]]];
+        $i++;
     }
     if (empty($retVal)) {
         echo json_encode("no-intersection");
@@ -467,8 +469,8 @@ if (isset($_POST["get_chug_info"])) {
     }
     // Order July ahead of August, for UI clarity.
     $sql .= "ORDER BY CASE WHEN (blockname LIKE '%July%' OR blockname LIKE '%july%') THEN CONCAT('a', blockname) " .
-        "WHEN (blockname LIKE '%Aug%' OR blockname LIKE '%aug%') THEN CONCAT('b', blockname) ELSE blockname END, " .
-        "groupname, chugname";
+        "WHEN (blockname LIKE '%Aug%' OR blockname LIKE '%aug%') THEN CONCAT('b', blockname) ELSE b.sort_order END, " .
+        "g.sort_order, chugname";
     $err = "";
     $result = $db->doQuery($sql, $err);
     if ($result == false) {

--- a/chugbot/camperUpload.php
+++ b/chugbot/camperUpload.php
@@ -55,7 +55,7 @@ foreach ($parts as $part) {
         $dbConn->isSelect = true;
         $sql = "SELECT e.name AS 'edah', s.name AS 'session', b.name AS 'bunk' FROM edot e, sessions s, bunks b, bunk_instances bi " . 
             "WHERE b.bunk_id = bi.bunk_id AND e.edah_id = bi.edah_id GROUP BY edah, session, bunk " . 
-            "ORDER BY e.sort_order, s.name, bunk+0>0 DESC, bunk+0, LENGTH(bunk), bunk;";
+            "ORDER BY e.sort_order, s.sort_order, bunk+0>0 DESC, bunk+0, LENGTH(bunk), bunk;";
         $result = $dbConn->doQuery($sql, $dbErr);
         if ($result == false) {
             error_log($dbErr);
@@ -87,7 +87,7 @@ while ($row = mysqli_fetch_array($result, MYSQLI_ASSOC)) {
 }
 
 $dbConn->isSelect = true;
-$sql = "SELECT * FROM sessions";
+$sql = "SELECT * FROM sessions ORDER BY sort_order";
 $result = $dbConn->doQuery($sql, $dbErr);
 if ($result == false) {
     error_log($dbErr);

--- a/chugbot/chugUpload.php
+++ b/chugbot/chugUpload.php
@@ -29,7 +29,7 @@ while ($row = mysqli_fetch_array($result, MYSQLI_ASSOC)) {
 }
 
 $dbConn->isSelect = true;
-$sql = "SELECT * FROM blocks";
+$sql = "SELECT * FROM blocks ORDER BY sort_order";
 $result = $dbConn->doQuery($sql, $dbErr);
 if ($result == false) {
     error_log($dbErr);
@@ -40,7 +40,7 @@ while ($row = mysqli_fetch_array($result, MYSQLI_ASSOC)) {
 }
 
 $dbConn->isSelect = true;
-$sql = "SELECT * FROM chug_groups";
+$sql = "SELECT * FROM chug_groups ORDER BY sort_order";
 $result = $dbConn->doQuery($sql, $dbErr);
 if ($result == false) {
     error_log($dbErr);

--- a/chugbot/dbConn.php
+++ b/chugbot/dbConn.php
@@ -298,7 +298,7 @@ function fillId2Name($archiveYear,
         $db->addSelectColumn($secondIdColumn);
     }
     $db->addSelectColumn("name");
-    if ($table == "edot") {
+    if ($table == "edot" || $table == "sessions" || $table == "blocks" || $table == "chug_groups") {
         $db->addSelectColumn("sort_order");
         $db->addOrderByClause(" ORDER BY sort_order");
     }

--- a/chugbot/editEdah.php
+++ b/chugbot/editEdah.php
@@ -46,11 +46,4 @@ $commentsField->setInputValue($editEdahPage->columnValue("comments"));
 $commentsField->setGuideText("Comments about this " . ucfirst(edah_term_singular) . " (optional)");
 $editEdahPage->addFormItem($commentsField);
 
-$sortOrderField = new FormItemSingleTextField("Sort Order", false, "sort_order", 4);
-$sortOrderField->setInputType("number");
-$sortOrderField->setInputMaxLength(3);
-$sortOrderField->setInputValue($editEdahPage->columnValue("sort_order"));
-$sortOrderField->setGuideText("Indicate where this " . (edah_term_singular) . " should appear when all " . edah_term_plural . " are sorted, with lower appearing earlier.  For example, if this is the youngest and that group should be listed first, enter 1.  If this group should appear third, enter 3.  If no choices are made for this box, edot will be listed alphabetically.");
-$editEdahPage->addFormItem($sortOrderField);
-
 $editEdahPage->renderForm();

--- a/chugbot/forgotPassword.php
+++ b/chugbot/forgotPassword.php
@@ -71,7 +71,7 @@ if ($uuid) {
     if ($matchedUuid == false) {
         fatalError("The reset code you supplied does not match any valid reset code.  Please try the reset link again.");
     }
-} else if ($_SERVER["REQUEST_METHOD"] == "POST") {
+} else if ($_SERVER["REQUEST_METHOD"] == "POST" && !isset($_POST["captcha"])) {
     if (!$_SESSION['reset_password_ok']) {
         fatalError("You must present a valid reset code before attempting a password reset");
     }
@@ -101,6 +101,11 @@ if ($uuid) {
     header("Location: $redirUrl");
     exit();
 } else {
+    // Begin by checking the CAPTCHA to ensure the page was properly reached by a person
+    if (!isset($_POST['captcha'])  || $_POST['captcha'] != $_SESSION['password_captcha_answer']) {
+        fatalError("Invalid CAPTCHA.");
+    }
+
     // If there's no POST data or UUID string, we need to generate a new code and
     // send an email.
     // Generate and send the email.  Display a message indicating the email status.

--- a/chugbot/formItem.php
+++ b/chugbot/formItem.php
@@ -447,13 +447,13 @@ function fillConstraints() {
            ourDropDown.empty();
            var html = "";
            var hadSel = 0;
-           $.each(data, function(itemId, itemName) {
-                  var optionText = "<option value=\"" + itemId + "\"";
-                  if (itemId == selected) {
+           $.each(data, function(_, item) {
+                  var optionText = "<option value=\"" + item.id + "\"";
+                  if (item.id == selected) {
                       optionText += " selected";
                       hadSel = 1;
                   }
-                  optionText += " >" + itemName + "</option>";
+                  optionText += " >" + item.name + "</option>";
                   html += optionText;
            });
            // Prepend a -- option for default choice.  Make this the selected

--- a/chugbot/levelingAjax.php
+++ b/chugbot/levelingAjax.php
@@ -450,7 +450,7 @@ if (isset($_POST["matches_and_prefs"])) {
     }
     $groupInText .= ")";
     $sql = "SELECT g.group_id group_id, g.name name FROM chug_groups g, edot_for_group e " .
-        "WHERE g.group_id = e.group_id AND $edahIdOrText $groupInText";
+        "WHERE g.group_id = e.group_id AND $edahIdOrText $groupInText ORDER BY g.sort_order";
     $result = $db->doQuery($sql, $dbErr);
     if ($result == false) {
         error_log("Unable to select chug_groups: $err");
@@ -459,6 +459,7 @@ if (isset($_POST["matches_and_prefs"])) {
     }
     $groupId2Name = array();
     $groupId2ChugId2MatchedCampers = array();
+    $groupIdSorted = array();
     while ($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
         $unAssignedCampersInThisGroup = $camperId2Name; // Make a copy
         $group_id = intval($row[0]);
@@ -466,6 +467,7 @@ if (isset($_POST["matches_and_prefs"])) {
         $groupId2Name[$group_id] = $group_name;
         if (!array_key_exists($group_id, $groupId2ChugId2MatchedCampers)) {
             $groupId2ChugId2MatchedCampers[$group_id] = array();
+            array_push($groupIdSorted, $group_id);
         }
         // Get all chugim for this group/edot, and make an array entry.
         $db = new DbConn();
@@ -543,6 +545,7 @@ if (isset($_POST["matches_and_prefs"])) {
     $retVal["groupId2ChugId2MatchedCampers"] = $groupId2ChugId2MatchedCampers; // {Group ID->{Chug ID->(Matched camper ID list - might be empty)}}
     $retVal["groupId2EdahId2AllowedChugim"] = $groupId2EdahId2AllowedChugim; // {Group ID->{Edah Id->array(allowed Chugim)}}
     $retVal["groupId2Name"] = $groupId2Name; // {Group ID -> Group Name}
+    $retVal["groupIdSorted"] = $groupIdSorted; // {sort_order -> groupId}
     $retVal["camperId2Name"] = $camperId2Name; // {Camper ID -> Camper Name}
     $retVal["camperId2Edah"] = $camperId2Edah; // {Camper ID -> Edah ID for that camper}
     $retVal["chugId2Beta"] = $chugId2Beta; // {Chug ID -> Chug Name, Allowed Edot, Min and Max}

--- a/chugbot/meta/design.js
+++ b/chugbot/meta/design.js
@@ -35,7 +35,7 @@ function setAdvanced(...params) {
         }
         sql += "?";
     }
-    sql += ") AND e.group_id = g.group_id GROUP BY e.group_id HAVING COUNT(e.edah_id) = " + ct;
+    sql += ") AND e.group_id = g.group_id GROUP BY e.group_id HAVING COUNT(e.edah_id) = " + ct + " ORDER BY g.sort_order";
     values["sql"] = sql;
     values["instance_ids"] = curSelectedEdahIds;
     var groupNames = [];
@@ -45,9 +45,9 @@ function setAdvanced(...params) {
         type: 'post',
         data: values,
         success: function(data) {
-            $.each(data, function(itemId, itemName) {
-                groupNames.push(itemName);
-                groupIds.push(itemId)
+            $.each(data, function(_, item) {
+                groupNames.push(item.name);
+                groupIds.push(item.id);
             });
         },
         error: function(xhr, desc, err) {
@@ -64,7 +64,7 @@ function setAdvanced(...params) {
         }
         sql += "?";
     }
-    sql += ") AND e.block_id = g.block_id GROUP BY e.block_id HAVING COUNT(e.edah_id) = " + ct;
+    sql += ") AND e.block_id = g.block_id GROUP BY e.block_id HAVING COUNT(e.edah_id) = " + ct + " ORDER BY g.sort_order";
     values["sql"] = sql;
     values["instance_ids"] = curSelectedEdahIds;
     const blockNames = [];
@@ -74,9 +74,9 @@ function setAdvanced(...params) {
         type: 'post',
         data: values,
         success: function(data) {
-            $.each(data, function(itemId, itemName) {
-                blockNames.push(itemName);
-                blockIds.push(itemId)
+            $.each(data, function(_, item) {
+                blockNames.push(item.name);
+                blockIds.push(item.id)
             });
         },
         error: function(xhr, desc, err) {

--- a/chugbot/meta/leveling.js
+++ b/chugbot/meta/leveling.js
@@ -86,26 +86,21 @@ function updateCount(chugId2Beta, curChugHolder) {
 	});
 }
 
-function sortedGroupIdKeysByName(groupId2ChugId2MatchedCampers, groupId2Name) {
+function sortedGroupIdKeys(groupId2ChugId2MatchedCampers, groupIdSorted) {
 	// Populate the sorted list.
-	var sorted = new Array();
+	var present = new Array();
 	for (var groupId in groupId2ChugId2MatchedCampers) {
-		sorted.push(groupId);
+		present.push(groupId);
 	}
-	// Do the actual sort by chug name, and return the sorted array.
-	sorted.sort(function (x, y) {
-		var xName = groupId2Name[x];
-		var yName = groupId2Name[y];
-		if (xName.toLowerCase() < yName.toLowerCase()) {
-			return -1;
+	
+	// Only include the groupIds which we have chugim for
+	groupIdSorted.forEach((id) => {
+		if(present.includes(toString(id))) {
+			groupIdSorted = groupIdSorted.filter(item => item !== id);
 		}
-		if (xName.toLowerCase() > yName.toLowerCase()) {
-			return 1;
-		}
-		return 0;
 	});
 
-	return sorted;
+	return groupIdSorted;
 }
 
 function chugIdsSortedByName(chugId2Beta, chugId2Entity) {
@@ -221,6 +216,7 @@ function displayChugimWithSpace(edah_ids, group_ids, block) {
 		success: function (json) {
 			// general info
 			var groupId2Name = json["groupId2Name"];
+			var groupIdSorted = json["groupIdSorted"];
 			var edahId2Name = json["edahId2Name"];
 			var chugId2Beta = json["chugId2Beta"];
 			var groupId2ChugId2MatchedCampers = json["groupId2ChugId2MatchedCampers"];
@@ -238,7 +234,7 @@ function displayChugimWithSpace(edah_ids, group_ids, block) {
 			freeHtml += "<div class=\"accordion\" id=\"chugimFreeSpaceAccordion\">";
 	
 			// go through each chug group
-			var sortedGroupIds = sortedGroupIdKeysByName(groupId2ChugId2MatchedCampers, groupId2Name);
+			var sortedGroupIds = sortedGroupIdKeys(groupId2ChugId2MatchedCampers, groupIdSorted);
 			for (var j = 0; j < sortedGroupIds.length; j++) {
 				var groupId = sortedGroupIds[j];
 				var chugId2MatchedCampers = groupId2ChugId2MatchedCampers[groupId];
@@ -381,6 +377,7 @@ function getAndDisplayCurrentMatches() {
 			var edahNames = json["edahNames"];
 			var blockName = json["blockName"];
 			var groupId2Name = json["groupId2Name"];
+			var groupIdSorted = json["groupIdSorted"];
 			var edahId2Name = json["edahId2Name"];
 			var showEdahForCamper = 0;
 			if (Object.keys(edahId2Name).length > 1) {
@@ -395,7 +392,7 @@ function getAndDisplayCurrentMatches() {
 			chugId2Beta = json["chugId2Beta"];
 			var camperId2Name = json["camperId2Name"];
 			camperId2Edah = json["camperId2Edah"];
-			var sortedGroupIds = sortedGroupIdKeysByName(groupId2ChugId2MatchedCampers, groupId2Name);
+			var sortedGroupIds = sortedGroupIdKeys(groupId2ChugId2MatchedCampers, groupIdSorted);
 			for (var j = 0; j < sortedGroupIds.length; j++) {
 				var groupId = sortedGroupIds[j];
 				var chugId2MatchedCampers = groupId2ChugId2MatchedCampers[groupId];

--- a/chugbot/robots.txt
+++ b/chugbot/robots.txt
@@ -1,0 +1,7 @@
+# Disallow all general bots:
+User-agent: *
+Disallow: /
+
+# Disallow Google adsbot (needs to be named separately)
+User-agent: AdsBot-Google
+Disallow: /


### PR DESCRIPTION
## sort_order

Custom sort for additional terms (instead of alphabetical - for example, "Dalet" used to show before "Gimel" because "D" comes before "G;" a user can now override that): blocks, chug_groups, sessions

Based on method for sorting edot.

Instead of having a number field to set the order of each term, there is a drag/drop from the general "manage" accordion on the staff homepage.

SQL command to update DB:

```
ALTER TABLE sessions ADD sort_order int NOT NULL DEFAULT '0';
ALTER TABLE blocks ADD sort_order int NOT NULL DEFAULT '0';
ALTER TABLE chug_groups ADD sort_order int NOT NULL DEFAULT '0';

```

## Reset Password Security

Implements two features to increase security and mitigate spam emails to administrators:
1. Requires a CAPTCHA before accessing forgotPassword.php (which sends an email to the admin with a reset password code).
    * The user just needs to sum 2 digits to access the password reset page; the provided sum must match the stored one to trigger an email.
3. Adds a robots.txt file to dissuade legitimate bots from crawling through the site.